### PR TITLE
창고 관리자 재고 현황 페이지 및 상세 모달 구현

### DIFF
--- a/src/api/inventory.js
+++ b/src/api/inventory.js
@@ -1,0 +1,160 @@
+/**
+ * inventory.js — 재고 현황 API 모듈
+ *
+ * 현재: mock 데이터 직접 반환 (Promise 래핑)
+ * 추후 백엔드 연동 시 아래처럼 교체:
+ *   import instance from './instance'
+ *   export function getInventories(params) { return instance.get('/inventories', { params }) }
+ *   export function getInventoryDetail(id)  { return instance.get(`/inventories/${id}`) }
+ */
+
+const MOCK_INVENTORIES = [
+  {
+    id: 1,
+    sku: 'SKU-GB-001',
+    name: '앰플 세럼 30ml',
+    seller: '(주)글로우뷰티',
+    availableQty: 23,
+    allocatedQty: 5,
+    damagedQty: 0,
+    totalQty: 28,
+    locations: [{ bin: 'A-3-2', qty: 28, asnId: 'ASN-2024-0309-002', receivedDate: '2026-03-09' }],
+    threshold: 100,
+    status: 'shortage',
+    history: [
+      { date: '2026-03-12 10:10', type: '주문 할당', qty: -5, docId: 'ORD-20240312-085' },
+      { date: '2026-03-09 16:45', type: '입고 확정', qty: 28, docId: 'ASN-2024-0309-002' },
+    ],
+  },
+  {
+    id: 2,
+    sku: 'SKU-GB-002',
+    name: '마스크팩 10매입',
+    seller: '(주)글로우뷰티',
+    availableQty: 710,
+    allocatedQty: 90,
+    damagedQty: 2,
+    totalQty: 802,
+    locations: [
+      { bin: 'A-3-3', qty: 500, asnId: 'ASN-2024-0307-001', receivedDate: '2026-03-07' },
+      { bin: 'B-1-2', qty: 302, asnId: 'ASN-2024-0310-004', receivedDate: '2026-03-10' },
+    ],
+    threshold: 200,
+    status: 'normal',
+    history: [
+      { date: '2026-03-13 09:00', type: '주문 할당', qty: -30, docId: 'ORD-20240313-012' },
+      { date: '2026-03-10 14:20', type: '입고 확정', qty: 302, docId: 'ASN-2024-0310-004' },
+      { date: '2026-03-07 11:00', type: '입고 확정', qty: 500, docId: 'ASN-2024-0307-001' },
+    ],
+  },
+  {
+    id: 3,
+    sku: 'SKU-GB-003',
+    name: '토너 100ml',
+    seller: '(주)글로우뷰티',
+    availableQty: 195,
+    allocatedQty: 5,
+    damagedQty: 0,
+    totalQty: 200,
+    locations: [{ bin: 'B-2-1', qty: 200, asnId: 'ASN-2024-0308-003', receivedDate: '2026-03-08' }],
+    threshold: 50,
+    status: 'normal',
+    history: [
+      { date: '2026-03-14 08:30', type: '주문 할당', qty: -5, docId: 'ORD-20240314-007' },
+      { date: '2026-03-08 13:15', type: '입고 확정', qty: 200, docId: 'ASN-2024-0308-003' },
+    ],
+  },
+  {
+    id: 4,
+    sku: 'SKU-KS-001',
+    name: '티셔츠 L사이즈',
+    seller: 'K-Style',
+    availableQty: 32,
+    allocatedQty: 10,
+    damagedQty: 1,
+    totalQty: 43,
+    locations: [{ bin: 'C-1-4', qty: 43, asnId: 'ASN-2024-0306-002', receivedDate: '2026-03-06' }],
+    threshold: 30,
+    status: 'caution',
+    history: [
+      { date: '2026-03-15 10:00', type: '주문 할당', qty: -10, docId: 'ORD-20240315-003' },
+      { date: '2026-03-06 15:30', type: '입고 확정', qty: 43, docId: 'ASN-2024-0306-002' },
+    ],
+  },
+  {
+    id: 5,
+    sku: 'SKU-EP-001',
+    name: '텀블러 350ml',
+    seller: '에코팩',
+    availableQty: 55,
+    allocatedQty: 20,
+    damagedQty: 0,
+    totalQty: 75,
+    locations: [{ bin: 'D-2-1', qty: 75, asnId: 'ASN-2024-0310-003', receivedDate: '2026-03-10' }],
+    threshold: 50,
+    status: 'caution',
+    history: [
+      { date: '2026-03-16 09:45', type: '주문 할당', qty: -20, docId: 'ORD-20240316-011' },
+      { date: '2026-03-10 16:00', type: '입고 확정', qty: 75, docId: 'ASN-2024-0310-003' },
+    ],
+  },
+  {
+    id: 6,
+    sku: 'SKU-KF-001',
+    name: '홍삼 진액 30포',
+    seller: 'K-Farm',
+    availableQty: 12,
+    allocatedQty: 0,
+    damagedQty: 0,
+    totalQty: 12,
+    locations: [{ bin: 'A-1-1', qty: 12, asnId: 'ASN-2024-0308-001', receivedDate: '2026-03-08' }],
+    threshold: 100,
+    status: 'shortage',
+    history: [
+      { date: '2026-03-08 12:00', type: '입고 확정', qty: 12, docId: 'ASN-2024-0308-001' },
+    ],
+  },
+  {
+    id: 7,
+    sku: 'SKU-BL-001',
+    name: 'BB크림 30ml',
+    seller: '뷰티랩',
+    availableQty: 380,
+    allocatedQty: 20,
+    damagedQty: 3,
+    totalQty: 403,
+    locations: [{ bin: 'B-3-2', qty: 403, asnId: 'ASN-2024-0309-005', receivedDate: '2026-03-09' }],
+    threshold: 80,
+    status: 'normal',
+    history: [
+      { date: '2026-03-13 11:30', type: '주문 할당', qty: -20, docId: 'ORD-20240313-020' },
+      { date: '2026-03-09 10:00', type: '입고 확정', qty: 403, docId: 'ASN-2024-0309-005' },
+    ],
+  },
+]
+
+export function getInventories(params = {}) {
+  let list = [...MOCK_INVENTORIES]
+
+  if (params.seller) {
+    list = list.filter(i => i.seller === params.seller)
+  }
+  if (params.status && params.status !== 'all') {
+    list = list.filter(i => i.status === params.status)
+  }
+  if (params.q) {
+    const q = params.q.toLowerCase()
+    list = list.filter(i =>
+      i.sku.toLowerCase().includes(q) ||
+      i.name.toLowerCase().includes(q) ||
+      i.seller.toLowerCase().includes(q),
+    )
+  }
+
+  return Promise.resolve({ data: list })
+}
+
+export function getInventoryDetail(id) {
+  const item = MOCK_INVENTORIES.find(i => i.id === id)
+  return Promise.resolve({ data: item ?? null })
+}

--- a/src/components/layout/Sidebar.vue
+++ b/src/components/layout/Sidebar.vue
@@ -33,13 +33,22 @@
  *   (Header.vue의 알림 패널은 @click.stop + document listener 패턴 사용)
  */
 import { computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { ROLES, ROUTE_NAMES } from '@/constants'
 import { MENU_BY_ROLE } from '@/components/layout/menus'
 
 const auth = useAuthStore()
 const route = useRoute()
+const router = useRouter()
+
+function routeExists(name) {
+  try {
+    return !!router.resolve({ name }).name
+  } catch {
+    return false
+  }
+}
 const DEV_COMPONENTS_ROUTE_NAME = 'dev-components'
 const DEV_MENU_GROUPS = [
   {

--- a/src/components/layout/menus/whManager.js
+++ b/src/components/layout/menus/whManager.js
@@ -23,4 +23,10 @@ export const WH_MANAGER_MENU_GROUPS = [
       { name: ROUTE_NAMES.WH_MANAGER_ASN_LIST, label: 'ASN 목록', icon: '📥' },
     ],
   },
+  {
+    label: '재고 관리',
+    items: [
+      { name: ROUTE_NAMES.WH_MANAGER_INVENTORY, label: '재고 현황', icon: '📦' },
+    ],
+  },
 ]

--- a/src/router/routes/whManager.js
+++ b/src/router/routes/whManager.js
@@ -13,4 +13,10 @@ export default [
     component: () => import('@/views/whManager/DashboardView.vue'),
     meta: { role: ROLES.WH_MANAGER },
   },
+  {
+    path: '/whm/inventory',
+    name: ROUTE_NAMES.WH_MANAGER_INVENTORY,
+    component: () => import('@/views/whManager/InventoryView.vue'),
+    meta: { role: ROLES.WH_MANAGER },
+  },
 ]

--- a/src/views/whManager/InventoryView.vue
+++ b/src/views/whManager/InventoryView.vue
@@ -1,0 +1,405 @@
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import BaseTable from '@/components/common/BaseTable.vue'
+import InventoryDetailModal from './components/InventoryDetailModal.vue'
+import { getInventories } from '@/api/inventory'
+
+// ── 필터 상태
+const searchText   = ref('')
+const filterSeller = ref('')
+const filterStatus = ref('all')
+
+// ── 페이지네이션
+const currentPage = ref(1)
+const PAGE_SIZE   = 7
+
+// ── 데이터
+const inventories = ref([])
+
+async function fetchInventories() {
+  const { data } = await getInventories()
+  inventories.value = data
+}
+
+onMounted(fetchInventories)
+
+// 필터 바뀌면 1페이지로 초기화
+watch([searchText, filterSeller, filterStatus], () => {
+  currentPage.value = 1
+})
+
+// ── 상태 매핑
+const STATUS_MAP = {
+  normal:   { label: '정상',      color: 'green' },
+  caution:  { label: '주의',      color: 'amber' },
+  shortage: { label: '재고 부족', color: 'red'   },
+  damaged:  { label: '불량',      color: 'red'   },
+}
+
+// ── KPI 집계
+const kpi = computed(() => ({
+  availableSkuCount: inventories.value.filter(i => i.availableQty > 0).length,
+  availableTotalQty: inventories.value.reduce((s, i) => s + i.availableQty, 0),
+  allocatedSkuCount: inventories.value.filter(i => i.allocatedQty > 0).length,
+  allocatedTotalQty: inventories.value.reduce((s, i) => s + i.allocatedQty, 0),
+  shortageCount:     inventories.value.filter(i => i.status === 'shortage').length,
+  damagedCount:      inventories.value.filter(i => i.damagedQty > 0).length,
+  damagedTotalQty:   inventories.value.reduce((s, i) => s + i.damagedQty, 0),
+}))
+
+// ── 클라이언트 필터링
+const filtered = computed(() => {
+  let list = inventories.value
+
+  if (filterSeller.value) {
+    list = list.filter(i => i.seller === filterSeller.value)
+  }
+  if (filterStatus.value !== 'all') {
+    list = list.filter(i => i.status === filterStatus.value)
+  }
+  if (searchText.value) {
+    const q = searchText.value.toLowerCase()
+    list = list.filter(i =>
+      i.sku.toLowerCase().includes(q) ||
+      i.name.toLowerCase().includes(q) ||
+      i.seller.toLowerCase().includes(q),
+    )
+  }
+
+  return list
+})
+
+// ── 페이지네이션
+const paged = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filtered.value.slice(start, start + PAGE_SIZE)
+})
+
+const pagination = computed(() => ({
+  page:     currentPage.value,
+  pageSize: PAGE_SIZE,
+  total:    filtered.value.length,
+}))
+
+// ── 셀러 목록 (중복 제거)
+const sellerOptions = computed(() =>
+  [...new Set(inventories.value.map(i => i.seller))],
+)
+
+// ── 컬럼 정의
+const columns = [
+  { key: 'sku',          label: 'SKU',      width: '130px' },
+  { key: 'name',         label: '품목명' },
+  { key: 'seller',       label: '셀러',     width: '150px' },
+  { key: 'availableQty', label: '가용 수량', align: 'right', width: '100px' },
+  { key: 'allocatedQty', label: '할당 수량', align: 'right', width: '100px' },
+  { key: 'damagedQty',   label: '불량 수량', align: 'right', width: '100px' },
+  { key: 'totalQty',     label: '총 수량',   align: 'right', width: '100px' },
+  { key: 'locations',    label: '보관 위치', width: '130px' },
+  { key: 'threshold',    label: '임계값',    align: 'right', width: '80px' },
+  { key: 'status',       label: '상태',      width: '110px' },
+  { key: 'actions',      label: '작업',      width: '70px', align: 'center' },
+]
+
+// ── 상세 모달
+const selectedItem = ref(null)
+
+function openDetail(item) {
+  selectedItem.value = item
+}
+function closeDetail() {
+  selectedItem.value = null
+}
+
+// ── 브레드크럼
+const breadcrumb = [
+  { label: 'CONK' },
+  { label: '재고 관리' },
+  { label: '재고 현황' },
+]
+</script>
+
+<template>
+  <AppLayout title="재고 현황" :breadcrumb="breadcrumb">
+
+    <!-- ── KPI 카드 4개 ───────────────────────────── -->
+    <div class="kpi-grid">
+
+      <div class="kpi-card" style="border-left: 3px solid var(--green);">
+        <div class="kpi-label">가용 재고 SKU</div>
+        <div class="kpi-value">{{ kpi.availableSkuCount }}</div>
+        <div class="kpi-sub">총 <strong>{{ kpi.availableTotalQty.toLocaleString() }}</strong>개 보관 중</div>
+      </div>
+
+      <div class="kpi-card" style="border-left: 3px solid var(--blue);">
+        <div class="kpi-label">할당 재고 SKU</div>
+        <div class="kpi-value">{{ kpi.allocatedSkuCount }}</div>
+        <div class="kpi-sub">출고 대기 <strong>{{ kpi.allocatedTotalQty.toLocaleString() }}</strong>개</div>
+      </div>
+
+      <div class="kpi-card" style="border-left: 3px solid var(--red);">
+        <div class="kpi-label">재고 부족 경고</div>
+        <div class="kpi-value kpi--red">{{ kpi.shortageCount }}</div>
+        <div class="kpi-sub">임계값 이하 SKU</div>
+      </div>
+
+      <div class="kpi-card" style="border-left: 3px solid #d97706;">
+        <div class="kpi-label">불량 재고</div>
+        <div class="kpi-value kpi--amber">{{ kpi.damagedCount }}</div>
+        <div class="kpi-sub">DAMAGED 격리 중</div>
+      </div>
+
+    </div>
+
+    <!-- ── 필터 + 테이블 카드 ─────────────────────── -->
+    <div class="card">
+
+      <!-- 필터 바 -->
+      <div class="filter-bar">
+        <div class="search-wrap">
+          <svg class="search-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6">
+            <circle cx="6.5" cy="6.5" r="4"/>
+            <path d="M10 10l3 3" stroke-linecap="round"/>
+          </svg>
+          <input
+            v-model="searchText"
+            class="search-input"
+            type="text"
+            placeholder="SKU, 품목명 검색..."
+          />
+        </div>
+
+        <select v-model="filterSeller" class="select-filter">
+          <option value="">전체 셀러</option>
+          <option v-for="seller in sellerOptions" :key="seller" :value="seller">{{ seller }}</option>
+        </select>
+
+        <select v-model="filterStatus" class="select-filter">
+          <option value="all">전체 상태</option>
+          <option value="normal">정상</option>
+          <option value="caution">주의</option>
+          <option value="shortage">재고 부족</option>
+          <option value="damaged">불량</option>
+        </select>
+      </div>
+
+      <!-- 테이블 -->
+      <div class="table-section">
+        <BaseTable
+          :columns="columns"
+          :rows="paged"
+          :pagination="pagination"
+          row-key="id"
+          @page-change="p => currentPage = p"
+        >
+          <!-- SKU: 모노스페이스 -->
+          <template #cell-sku="{ row }">
+            <span class="mono">{{ row.sku }}</span>
+          </template>
+
+          <!-- 품목명: 볼드 -->
+          <template #cell-name="{ row }">
+            <strong>{{ row.name }}</strong>
+          </template>
+
+          <!-- 가용 수량: 부족이면 빨간색 -->
+          <template #cell-availableQty="{ row }">
+            <span
+              class="fw-600"
+              :class="row.status === 'shortage' ? 'text-red' : row.status === 'caution' ? 'text-amber' : 'text-green'"
+            >
+              {{ row.availableQty.toLocaleString() }}
+            </span>
+          </template>
+
+          <!-- 할당 수량 -->
+          <template #cell-allocatedQty="{ row }">
+            {{ row.allocatedQty.toLocaleString() }}
+          </template>
+
+          <!-- 불량 수량 -->
+          <template #cell-damagedQty="{ row }">
+            <span :class="row.damagedQty > 0 ? 'text-red' : ''">
+              {{ row.damagedQty.toLocaleString() }}
+            </span>
+          </template>
+
+          <!-- 총 수량: 볼드 -->
+          <template #cell-totalQty="{ row }">
+            <span class="fw-600">{{ row.totalQty.toLocaleString() }}</span>
+          </template>
+
+          <!-- 보관 위치: location-tag -->
+          <template #cell-locations="{ row }">
+            <span v-for="loc in row.locations" :key="loc.bin" class="location-tag">{{ loc.bin }}</span>
+          </template>
+
+          <!-- 임계값: 회색 -->
+          <template #cell-threshold="{ row }">
+            <span class="text-muted">{{ row.threshold.toLocaleString() }}</span>
+          </template>
+
+          <!-- 상태 배지 -->
+          <template #cell-status="{ row }">
+            <span class="badge" :class="`badge--${STATUS_MAP[row.status]?.color}`">
+              {{ STATUS_MAP[row.status]?.label ?? row.status }}
+            </span>
+          </template>
+
+          <!-- 작업 버튼 -->
+          <template #cell-actions="{ row }">
+            <button class="ui-btn ui-btn--ghost ui-btn--sm" @click="openDetail(row)">상세</button>
+          </template>
+        </BaseTable>
+      </div>
+
+    </div>
+
+    <!-- ── 상세 모달 ──────────────────────────────── -->
+    <InventoryDetailModal :item="selectedItem" @close="closeDetail" />
+
+  </AppLayout>
+</template>
+
+<style scoped>
+/* ── KPI Grid ──────────────────────────────────── */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.kpi-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+}
+
+.kpi-label { font-size: var(--font-size-sm); color: var(--t3); margin-bottom: var(--space-2); }
+.kpi-value {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  color: var(--t1);
+  line-height: 1.1;
+  margin-bottom: var(--space-2);
+}
+.kpi-sub   { font-size: var(--font-size-xs); color: var(--t3); }
+.kpi--red  { color: var(--red); }
+.kpi--amber { color: #b45309; }
+
+/* ── Card ──────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+/* ── Filter Bar ────────────────────────────────── */
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+.search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.search-icon {
+  position: absolute;
+  left: 10px;
+  width: 14px;
+  height: 14px;
+  color: var(--t3);
+  pointer-events: none;
+}
+.search-input {
+  height: 36px;
+  padding: 0 12px 0 32px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--t1);
+  font-size: var(--font-size-sm);
+  width: 220px;
+  outline: none;
+  transition: border-color var(--ease-fast);
+}
+.search-input:focus { border-color: var(--blue); }
+
+.select-filter {
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--t1);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+/* ── Table Section ─────────────────────────────── */
+.table-section { padding: var(--space-4); }
+
+/* ── Cell Helpers ──────────────────────────────── */
+.mono    { font-family: var(--font-mono); font-size: var(--font-size-xs); }
+.fw-600  { font-weight: 600; }
+.text-muted  { color: var(--t3); }
+.text-green  { color: var(--green); }
+.text-amber  { color: #b45309; }
+.text-red    { color: var(--red); }
+
+.location-tag {
+  display: inline-flex;
+  padding: 2px 7px;
+  background: var(--blue-pale);
+  color: var(--blue);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  font-family: var(--font-mono);
+  margin-right: 4px;
+}
+
+/* ── Status Badge ──────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.badge--green { background: var(--green-pale); color: var(--green); }
+.badge--amber { background: var(--amber-pale); color: #b45309; }
+.badge--red   { background: var(--red-pale);   color: var(--red);   }
+
+/* ── Buttons ───────────────────────────────────── */
+.ui-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  height: 32px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--t2);
+  transition: background var(--ease-fast), color var(--ease-fast);
+}
+.ui-btn--ghost:hover { background: var(--surface-2); color: var(--t1); }
+.ui-btn--sm { height: 28px; padding: 0 var(--space-3); }
+</style>

--- a/src/views/whManager/components/InventoryDetailModal.vue
+++ b/src/views/whManager/components/InventoryDetailModal.vue
@@ -1,0 +1,366 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  item: { type: Object, default: null },
+})
+
+const emit = defineEmits(['close'])
+
+const STATUS_MAP = {
+  normal:   { label: '정상',       badgeClass: 'badge--green' },
+  caution:  { label: '주의',       badgeClass: 'badge--amber' },
+  shortage: { label: '재고 부족',  badgeClass: 'badge--red'   },
+  damaged:  { label: '불량',       badgeClass: 'badge--red'   },
+}
+
+const statusInfo = computed(() => STATUS_MAP[props.item?.status] ?? { label: props.item?.status, badgeClass: '' })
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="item" class="modal-overlay" @click.self="emit('close')">
+      <div class="modal modal-xl">
+
+        <!-- 헤더 -->
+        <div class="modal-header">
+          <div class="modal-title">재고 상세 정보</div>
+          <button class="modal-close" @click="emit('close')">
+            <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6" width="14" height="14">
+              <path d="M3 3l8 8M11 3l-8 8" stroke-linecap="round"/>
+            </svg>
+          </button>
+        </div>
+
+        <!-- 바디 -->
+        <div class="modal-body">
+
+          <!-- Hero -->
+          <div class="modal-hero">
+            <div class="modal-hero-top">
+              <div>
+                <div class="modal-eyebrow">Inventory Drilldown</div>
+                <div class="modal-hero-title">{{ item.sku }} · {{ item.name }}</div>
+                <div class="modal-hero-copy">가용/할당 재고와 실제 적재 로케이션, 최근 입출고 이력을 함께 보는 상세 모달입니다.</div>
+              </div>
+              <span class="badge" :class="statusInfo.badgeClass">{{ statusInfo.label }}</span>
+            </div>
+
+            <div class="metric-grid">
+              <div class="metric-card">
+                <span class="metric-label">가용 재고</span>
+                <span class="metric-value">{{ item.availableQty.toLocaleString() }}</span>
+                <span class="metric-sub">출고 가능</span>
+              </div>
+              <div class="metric-card">
+                <span class="metric-label">할당 재고</span>
+                <span class="metric-value">{{ item.allocatedQty.toLocaleString() }}</span>
+                <span class="metric-sub">주문 배정 수량</span>
+              </div>
+              <div class="metric-card">
+                <span class="metric-label">총 재고</span>
+                <span class="metric-value">{{ item.totalQty.toLocaleString() }}</span>
+                <span class="metric-sub">{{ item.locations.length > 1 ? `${item.locations.length}개 Bin 보관` : '단일 Bin 보관' }}</span>
+              </div>
+              <div class="metric-card">
+                <span class="metric-label">임계값</span>
+                <span class="metric-value" :class="item.availableQty < item.threshold ? 'value--red' : ''">
+                  {{ item.threshold.toLocaleString() }}
+                </span>
+                <span class="metric-sub">{{ item.availableQty < item.threshold ? '보충 필요' : '정상 범위' }}</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- 적재 로케이션 -->
+          <div class="modal-section">
+            <div class="section-title">적재 로케이션</div>
+            <div class="section-copy">현재 보관 위치와 입고 출처를 함께 확인합니다.</div>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Bin</th>
+                    <th>수량</th>
+                    <th>입고 ASN</th>
+                    <th>입고일</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="loc in item.locations" :key="loc.bin">
+                    <td><span class="location-tag">{{ loc.bin }}</span></td>
+                    <td>{{ loc.qty.toLocaleString() }}</td>
+                    <td class="mono">{{ loc.asnId }}</td>
+                    <td>{{ loc.receivedDate }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- 최근 재고 변동 -->
+          <div class="modal-section">
+            <div class="section-title">최근 재고 변동</div>
+            <div class="section-copy">입고/할당 흐름을 시간순으로 확인합니다.</div>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>일시</th>
+                    <th>유형</th>
+                    <th>수량</th>
+                    <th>관련 문서</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(h, idx) in item.history" :key="idx">
+                    <td>{{ h.date }}</td>
+                    <td>{{ h.type }}</td>
+                    <td :class="h.qty > 0 ? 'qty-plus' : 'qty-minus'">
+                      {{ h.qty > 0 ? `+${h.qty.toLocaleString()}` : h.qty.toLocaleString() }}
+                    </td>
+                    <td class="mono">{{ h.docId }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+        </div>
+
+        <!-- 푸터 -->
+        <div class="modal-footer">
+          <button class="ui-btn ui-btn--primary" @click="emit('close')">확인</button>
+        </div>
+
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+/* ── Overlay ───────────────────────────────────── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--space-6);
+}
+
+/* ── Modal Shell ───────────────────────────────── */
+.modal {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  overflow: hidden;
+}
+.modal-xl { width: 100%; max-width: 780px; }
+
+/* ── Header ────────────────────────────────────── */
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-5) var(--space-6);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.modal-title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--t1);
+}
+.modal-close {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--t3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  transition: background var(--ease-fast), color var(--ease-fast);
+}
+.modal-close:hover { background: var(--surface-2); color: var(--t1); }
+
+/* ── Body ──────────────────────────────────────── */
+.modal-body {
+  overflow-y: auto;
+  flex: 1;
+}
+
+/* ── Hero ──────────────────────────────────────── */
+.modal-hero {
+  padding: var(--space-6);
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+.modal-hero-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+}
+.modal-eyebrow {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--blue);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-1);
+}
+.modal-hero-title {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--t1);
+  margin-bottom: var(--space-2);
+}
+.modal-hero-copy {
+  font-size: var(--font-size-sm);
+  color: var(--t3);
+  line-height: 1.5;
+}
+
+/* ── Metric Grid ───────────────────────────────── */
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-3);
+}
+.metric-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.metric-label {
+  font-size: var(--font-size-xs);
+  color: var(--t3);
+}
+.metric-value {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  color: var(--t1);
+  line-height: 1.1;
+}
+.metric-sub {
+  font-size: var(--font-size-xs);
+  color: var(--t3);
+}
+.value--red { color: var(--red); }
+
+/* ── Section ───────────────────────────────────── */
+.modal-section {
+  padding: var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+.modal-section:last-child { border-bottom: none; }
+
+.section-title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--t1);
+  margin-bottom: var(--space-1);
+}
+.section-copy {
+  font-size: var(--font-size-xs);
+  color: var(--t3);
+  margin-bottom: var(--space-4);
+}
+
+/* ── Table ─────────────────────────────────────── */
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; font-size: var(--font-size-sm); }
+thead th {
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--t3);
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+}
+tbody td {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border);
+  color: var(--t1);
+}
+tbody tr:last-child td { border-bottom: none; }
+
+.location-tag {
+  display: inline-flex;
+  padding: 2px 8px;
+  background: var(--blue-pale);
+  color: var(--blue);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  font-family: var(--font-mono);
+}
+.mono {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+.qty-plus { color: var(--green); font-weight: 600; }
+.qty-minus { color: var(--red);   font-weight: 600; }
+
+/* ── Badge ─────────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.badge--green { background: var(--green-pale); color: var(--green); }
+.badge--amber { background: var(--amber-pale); color: #b45309; }
+.badge--red   { background: var(--red-pale);   color: var(--red);   }
+
+/* ── Footer ────────────────────────────────────── */
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--space-4) var(--space-6);
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* ── Buttons ───────────────────────────────────── */
+.ui-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-4);
+  height: 36px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background var(--ease-fast), color var(--ease-fast);
+}
+.ui-btn--primary {
+  background: var(--blue);
+  color: #fff;
+  border-color: var(--blue);
+}
+.ui-btn--primary:hover { opacity: 0.88; }
+</style>


### PR DESCRIPTION
## 💡 관련 이슈
- close #39 

## 📝 변경 사항
- 창고 관리자 재고 현황 페이지 신규 구현
- 재고 상세 정보 모달 컴포넌트 구현
- 사이드바에 재고 관리 메뉴 추가

## 🔍 주요 작업 내용
- [x] Frontend: (수정된 화면이나 컴포넌트)
    - `src/api/inventory.js` — 재고 조회 API 모듈 신규 추가 (mock → 실 API 교체 구조 준비)
    - `src/views/whManager/InventoryView.vue` — KPI 카드 4개, 필터(셀러/상태/검색), 페이지네이션 테이블 구현
    - `src/views/whManager/components/InventoryDetailModal.vue` — 적재 로케이션·입출고 이력 상세 모달 구현
    - `src/router/routes/whManager.js` — `/whm/inventory` 라우트 추가
    - `src/components/layout/menus/whManager.js` — 재고 관리 메뉴 항목 추가
    - `src/components/layout/Sidebar.vue` — 미등록 라우트 접근 에러 방지용 `routeExists()` 함수 추가

## 📸 스크린샷 (선택)
<img width="1919" height="943" alt="image" src="https://github.com/user-attachments/assets/63bf17c9-22cd-4adb-bda7-9aef580535b2" />

<img width="1919" height="941" alt="image" src="https://github.com/user-attachments/assets/4fcb4969-f699-4657-ae80-d57c9d18eeba" />

## 💬 리뷰어에게 한마디
- `STATUS_MAP`이 `InventoryView`와 `InventoryDetailModal` 두 곳에 중복 선언되어 있습니다. 현재는 이 기능에서만 사용 중이라 각 컴포넌트 내부에 뒀는데, 다른 화면에서도 동일한 상태값을 쓰게 되면 `src/constants`로 분리할
  예정입니다.
