### PR TITLE
fix: 브랜치 머지 충돌로 인한 JSON/JS 문법 오류 수정

### DIFF
--- a/mock-server/data/wh-manager.json
+++ b/mock-server/data/wh-manager.json
@@ -773,6 +773,8 @@
     { "id": "WORKER-001", "name": "박민준" },
     { "id": "WORKER-002", "name": "이서윤" },
     { "id": "WORKER-003", "name": "최현우" }
+  ],
+
   "wh_orders": [
     {
       "id": "ORD-20260313-101",

--- a/src/components/layout/menus/whManager.js
+++ b/src/components/layout/menus/whManager.js
@@ -30,12 +30,15 @@ export const WH_MANAGER_MENU_GROUPS = [
     ],
   },
   {
-    label: '출고 관리',
-    items: [
-      { name: ROUTE_NAMES.WH_MANAGER_OUTBOUND_DISPATCH, label: '출고 지시', icon: '🚚' },
     label: '주문 관리',
     items: [
       { name: ROUTE_NAMES.WH_MANAGER_ORDER_LIST, label: '주문 목록', icon: '📋' },
+    ],
+  },
+  {
+    label: '출고 관리',
+    items: [
+      { name: ROUTE_NAMES.WH_MANAGER_OUTBOUND_DISPATCH, label: '출고 지시', icon: '🚚' },
     ],
   },
 ]

--- a/src/router/routes/whManager.js
+++ b/src/router/routes/whManager.js
@@ -20,12 +20,15 @@ export default [
     meta: { role: ROLES.WH_MANAGER },
   },
   {
-    path: '/whm/outbound/dispatch',
-    name: ROUTE_NAMES.WH_MANAGER_OUTBOUND_DISPATCH,
-    component: () => import('@/views/whManager/OutboundDispatchView.vue'),
     path: '/whm/order-list',
     name: ROUTE_NAMES.WH_MANAGER_ORDER_LIST,
     component: () => import('@/views/whManager/OrderListView.vue'),
+    meta: { role: ROLES.WH_MANAGER },
+  },
+  {
+    path: '/whm/outbound/dispatch',
+    name: ROUTE_NAMES.WH_MANAGER_OUTBOUND_DISPATCH,
+    component: () => import('@/views/whManager/OutboundDispatchView.vue'),
     meta: { role: ROLES.WH_MANAGER },
   },
 ]


### PR DESCRIPTION
## 💡 관련 이슈
- close #60 

## 📝 변경 사항
- 이번 PR에서 작업한 내용을 간단히 적어주세요.
- 예: 발주 등록 API 구현 및 MyBatis 매퍼 작성

## 🔍 주요 작업 내용
- [] Frontend:
    - `mock-server/data/wh-manager.json` — `wh_workers` 배열 누락된 `],` 추가
    - `src/router/routes/whManager.js` — 하나의 객체로 합쳐진 주문 목록·출고 지시 라우트 분리
    - `src/components/layout/menus/whManager.js` — 하나의 객체로 합쳐진 주문 관리·출고 관리 사이드바 그룹 분리
    
## 📸 스크린샷 (선택)

## 💬 리뷰어에게 한마디
