### PR TITLE
창고 관리자 송장 발행 및 출고 확정 페이지 구현

### DIFF
--- a/mock-server/data/wh-manager.json
+++ b/mock-server/data/wh-manager.json
@@ -963,5 +963,160 @@
         { "sequence": 3, "bin": "D-1-3", "sku": "SKU-BB-001", "productName": "BB크림",        "qty": 1, "status": "WAITING" }
       ]
     }
+  ],
+  "wh_outbound_confirm_orders": [
+    {
+      "id": "ORD-20240312-071",
+      "sellerName": "(주)글로우뷰티",
+      "itemSummary": "앰플 세럼 30ml × 2",
+      "carrier": "USPS",
+      "service": "Priority Mail",
+      "trackingNumber": "9400111899223374693900",
+      "shipState": "CA",
+      "shipCountry": "USA",
+      "labelIssuedAt": "2026-03-12",
+      "status": "PENDING_CONFIRM",
+      "skuDeductions": [
+        { "sku": "SKU-GB-001", "productName": "앰플 세럼 30ml", "qty": 2 }
+      ]
+    },
+    {
+      "id": "ORD-20240312-070",
+      "sellerName": "K-Style",
+      "itemSummary": "티셔츠 L × 3",
+      "carrier": "UPS",
+      "service": "Ground",
+      "trackingNumber": "1Z999AA10123456784",
+      "shipState": "TX",
+      "shipCountry": "USA",
+      "labelIssuedAt": "2026-03-12",
+      "status": "PENDING_CONFIRM",
+      "skuDeductions": [
+        { "sku": "SKU-KS-001", "productName": "티셔츠 L사이즈", "qty": 3 }
+      ]
+    },
+    {
+      "id": "ORD-20240311-065",
+      "sellerName": "에코팩",
+      "itemSummary": "텀블러 × 2",
+      "carrier": "FedEx",
+      "service": "Home Delivery",
+      "trackingNumber": "274899940814173",
+      "shipState": "NY",
+      "shipCountry": "USA",
+      "labelIssuedAt": "2026-03-11",
+      "status": "PENDING_CONFIRM",
+      "skuDeductions": [
+        { "sku": "SKU-EP-001", "productName": "텀블러 350ml", "qty": 2 }
+      ]
+    },
+    {
+      "id": "ORD-20240311-062",
+      "sellerName": "K-Farm",
+      "itemSummary": "홍삼 진액 × 1",
+      "carrier": "USPS",
+      "service": "Priority Mail",
+      "trackingNumber": "9400111899223374693920",
+      "shipState": "WA",
+      "shipCountry": "USA",
+      "labelIssuedAt": "2026-03-11",
+      "status": "CONFIRMED",
+      "skuDeductions": [
+        { "sku": "SKU-KF-001", "productName": "홍삼 진액 30포", "qty": 1 }
+      ]
+    }
+  ],
+  "wh_invoice_orders": [
+    {
+      "id": "ORD-20240312-071",
+      "sellerName": "(주)글로우뷰티",
+      "itemSummary": "앰플 세럼 30ml × 2",
+      "weightLbs": 0.8,
+      "shipState": "CA",
+      "shipCountry": "USA",
+      "recommendedCarrier": "USPS",
+      "recommendedService": "Priority Mail",
+      "estimatedRate": 6.42,
+      "labelStatus": "NOT_ISSUED",
+      "labelIssuedAt": null,
+      "rates": [
+        { "carrier": "USPS", "service": "Priority Mail",   "rate": 6.42  },
+        { "carrier": "UPS",  "service": "Ground",          "rate": 8.10  },
+        { "carrier": "FedEx","service": "Home Delivery",   "rate": 9.35  }
+      ]
+    },
+    {
+      "id": "ORD-20240312-070",
+      "sellerName": "K-Style",
+      "itemSummary": "티셔츠 L × 3",
+      "weightLbs": 1.5,
+      "shipState": "TX",
+      "shipCountry": "USA",
+      "recommendedCarrier": "UPS",
+      "recommendedService": "Ground",
+      "estimatedRate": 8.95,
+      "labelStatus": "NOT_ISSUED",
+      "labelIssuedAt": null,
+      "rates": [
+        { "carrier": "USPS", "service": "Priority Mail",   "rate": 9.80  },
+        { "carrier": "UPS",  "service": "Ground",          "rate": 8.95  },
+        { "carrier": "FedEx","service": "Home Delivery",   "rate": 10.20 }
+      ]
+    },
+    {
+      "id": "ORD-20240311-068",
+      "sellerName": "K-Farm",
+      "itemSummary": "홍삼 진액 × 1",
+      "weightLbs": 0.5,
+      "shipState": "WA",
+      "shipCountry": "USA",
+      "recommendedCarrier": "USPS",
+      "recommendedService": "First Class",
+      "estimatedRate": 5.15,
+      "labelStatus": "ISSUED",
+      "labelIssuedAt": "2026-03-11",
+      "trackingNumber": "9400111899223374693900",
+      "rates": [
+        { "carrier": "USPS", "service": "First Class",     "rate": 5.15  },
+        { "carrier": "UPS",  "service": "Ground",          "rate": 7.40  },
+        { "carrier": "FedEx","service": "Home Delivery",   "rate": 8.60  }
+      ]
+    },
+    {
+      "id": "ORD-20240311-065",
+      "sellerName": "에코팩",
+      "itemSummary": "텀블러 × 2",
+      "weightLbs": 2.0,
+      "shipState": "NY",
+      "shipCountry": "USA",
+      "recommendedCarrier": "FedEx",
+      "recommendedService": "Home Delivery",
+      "estimatedRate": 12.30,
+      "labelStatus": "NOT_ISSUED",
+      "labelIssuedAt": null,
+      "rates": [
+        { "carrier": "USPS", "service": "Priority Mail",   "rate": 14.50 },
+        { "carrier": "UPS",  "service": "Ground",          "rate": 13.80 },
+        { "carrier": "FedEx","service": "Home Delivery",   "rate": 12.30 }
+      ]
+    },
+    {
+      "id": "ORD-20240311-063",
+      "sellerName": "(주)글로우뷰티",
+      "itemSummary": "마스크팩 10매 × 3",
+      "weightLbs": 1.2,
+      "shipState": "FL",
+      "shipCountry": "USA",
+      "recommendedCarrier": "USPS",
+      "recommendedService": "Priority Mail",
+      "estimatedRate": 7.80,
+      "labelStatus": "NOT_ISSUED",
+      "labelIssuedAt": null,
+      "rates": [
+        { "carrier": "USPS", "service": "Priority Mail",   "rate": 7.80  },
+        { "carrier": "UPS",  "service": "Ground",          "rate": 9.20  },
+        { "carrier": "FedEx","service": "Home Delivery",   "rate": 10.05 }
+      ]
+    }
   ]
 }

--- a/src/api/wh-manager.js
+++ b/src/api/wh-manager.js
@@ -36,3 +36,33 @@ export function getWhmPickingLists(params) {
 export function getWhmPickingListDetail(id) {
   return instance.get(`/wh_picking_lists/${id}`)
 }
+
+/** 송장 발행 대기 주문 목록 조회 */
+export function getWhmInvoiceOrders(params) {
+  return instance.get('/wh_invoice_orders', { params })
+}
+
+/** 개별 라벨 발행 */
+export function issueLabel(id, data) {
+  return instance.patch(`/wh_invoice_orders/${id}`, data)
+}
+
+/** 일괄 라벨 출력 */
+export function bulkIssueLabels(data) {
+  return instance.post('/wh_invoice_orders/bulk_label', data)
+}
+
+/** 출고 확정 대기 주문 목록 조회 */
+export function getWhmOutboundConfirmOrders(params) {
+  return instance.get('/wh_outbound_confirm_orders', { params })
+}
+
+/** 개별 출고 확정 */
+export function confirmSingleOutbound(id, data) {
+  return instance.patch(`/wh_outbound_confirm_orders/${id}`, data)
+}
+
+/** 일괄 출고 확정 */
+export function bulkConfirmOutbound(data) {
+  return instance.post('/wh_outbound_confirm_orders/bulk_confirm', data)
+}

--- a/src/components/common/StatusBadge.vue
+++ b/src/components/common/StatusBadge.vue
@@ -48,7 +48,7 @@
  *   <StatusBadge :status="item.status" type="item" />
  */
 import { computed } from 'vue'
-import { ACCOUNT_STATUS, ASN_STATUS, ITEM_STATUS, ORDER_STATUS, PICKING_LIST_STATUS, WORKER_STATUS } from '@/constants'
+import { ACCOUNT_STATUS, ASN_STATUS, ITEM_STATUS, LABEL_STATUS, ORDER_STATUS, OUTBOUND_CONFIRM_STATUS, PICKING_LIST_STATUS, WORKER_STATUS } from '@/constants'
 
 const props = defineProps({
   status: { type: String, required: true },
@@ -91,6 +91,19 @@ const MAP = {
     [PICKING_LIST_STATUS.WAITING]:     { label: '대기',    color: 'default' },
     [PICKING_LIST_STATUS.IN_PROGRESS]: { label: '진행 중', color: 'amber'   },
     [PICKING_LIST_STATUS.COMPLETED]:   { label: '완료',    color: 'green'   },
+  },
+  labelStatus: {
+    [LABEL_STATUS.NOT_ISSUED]: { label: '라벨 미발행',   color: 'amber' },
+    [LABEL_STATUS.ISSUED]:     { label: '라벨 발행 완료', color: 'green' },
+  },
+  carrier: {
+    USPS:  { label: 'USPS',  color: 'green'  },
+    UPS:   { label: 'UPS',   color: 'blue'   },
+    FedEx: { label: 'FedEx', color: 'purple' },
+  },
+  outboundConfirm: {
+    [OUTBOUND_CONFIRM_STATUS.PENDING_CONFIRM]: { label: '인계 완료',    color: 'amber' },
+    [OUTBOUND_CONFIRM_STATUS.CONFIRMED]:       { label: '출고 확정 완료', color: 'green' },
   },
 }
 

--- a/src/components/layout/menus/whManager.js
+++ b/src/components/layout/menus/whManager.js
@@ -40,6 +40,8 @@ export const WH_MANAGER_MENU_GROUPS = [
     items: [
       { name: ROUTE_NAMES.WH_MANAGER_OUTBOUND_DISPATCH, label: '출고 지시',   icon: '🚚' },
       { name: ROUTE_NAMES.WH_MANAGER_PICKING_LIST,      label: '피킹 리스트', icon: '📋' },
+      { name: ROUTE_NAMES.WH_MANAGER_LABEL_PRINT,       label: '송장 발행',   icon: '🏷️' },
+      { name: ROUTE_NAMES.WH_MANAGER_OUTBOUND_CONFIRM,  label: '출고 확정',   icon: '✅' },
     ],
   },
 ]

--- a/src/components/whManager/BulkLabelModal.vue
+++ b/src/components/whManager/BulkLabelModal.vue
@@ -1,0 +1,194 @@
+<script setup>
+import { computed } from 'vue'
+import BaseModal from '@/components/common/BaseModal.vue'
+
+const props = defineProps({
+  isOpen:         { type: Boolean, required: true },
+  selectedOrders: { type: Array,   default: () => [] },
+})
+
+const emit = defineEmits(['confirm', 'cancel'])
+
+const avgRate = computed(() => {
+  if (!props.selectedOrders.length) return '0.00'
+  const total = props.selectedOrders.reduce((acc, o) => acc + o.estimatedRate, 0)
+  return (total / props.selectedOrders.length).toFixed(2)
+})
+</script>
+
+<template>
+  <BaseModal
+    title="일괄 라벨 출력"
+    :isOpen="isOpen"
+    width="560px"
+    @cancel="$emit('cancel')"
+  >
+    <!-- 히어로 -->
+    <div class="hero">
+      <div class="hero-top">
+        <div>
+          <div class="eyebrow">Batch Label Print</div>
+          <div class="hero-title">{{ selectedOrders.length }}건 라벨 일괄 출력</div>
+          <div class="hero-copy">주문별 추천 배송사 결과를 기준으로 PDF를 묶어서 출력합니다.</div>
+        </div>
+        <span class="badge badge--blue">PDF 묶음 생성</span>
+      </div>
+      <div class="metric-grid">
+        <div class="metric-card">
+          <span class="metric-label">대상 주문</span>
+          <span class="metric-value">{{ selectedOrders.length }}건</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">최저요금 평균</span>
+          <span class="metric-value">${{ avgRate }}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">출력 형식</span>
+          <span class="metric-value">PDF</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- 경고 -->
+    <div class="callout callout--warning">
+      <div class="callout-title">출력 전 확인</div>
+      <div class="callout-copy">배송사 추천 결과가 최저 요금 기준으로 선택되었는지, 그리고 예외 주문이 포함되지 않았는지 확인하세요.</div>
+    </div>
+
+    <template #footer>
+      <div class="footer-row">
+        <button class="ui-btn ui-btn--ghost" @click="$emit('cancel')">취소</button>
+        <button class="ui-btn ui-btn--primary" @click="emit('confirm')">출력 시작</button>
+      </div>
+    </template>
+  </BaseModal>
+</template>
+
+<style scoped>
+/* ── 히어로 ────────────────────────────────────── */
+.hero {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.hero-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.eyebrow {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--blue);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-1);
+}
+
+.hero-title {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--t1);
+  margin-bottom: var(--space-1);
+}
+
+.hero-copy {
+  font-size: var(--font-size-xs);
+  color: var(--t3);
+  line-height: 1.5;
+}
+
+/* ── 메트릭 카드 ─────────────────────────────── */
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+}
+
+.metric-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.metric-label { font-size: var(--font-size-xs); color: var(--t3); }
+.metric-value {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--t1);
+}
+
+/* ── callout ────────────────────────────────── */
+.callout {
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-2);
+}
+
+.callout--warning {
+  background: var(--amber-pale);
+  border: 1px solid #d97706;
+}
+
+.callout-title {
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  color: #b45309;
+  margin-bottom: var(--space-1);
+}
+
+.callout-copy {
+  font-size: var(--font-size-xs);
+  color: var(--t2);
+  line-height: 1.5;
+}
+
+/* ── 배지 ────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.badge--blue { background: var(--blue-pale); color: var(--blue); }
+
+/* ── Footer ──────────────────────────────── */
+.footer-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.ui-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-4);
+  height: 36px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.ui-btn--primary { background: var(--blue); color: #fff; }
+.ui-btn--primary:hover { opacity: 0.9; }
+.ui-btn--ghost { border-color: var(--border); background: transparent; color: var(--t2); }
+.ui-btn--ghost:hover { background: var(--surface-2); color: var(--t1); }
+</style>

--- a/src/components/whManager/BulkOutboundConfirmModal.vue
+++ b/src/components/whManager/BulkOutboundConfirmModal.vue
@@ -1,0 +1,291 @@
+<script setup>
+import { ref, computed } from 'vue'
+import BaseModal from '@/components/common/BaseModal.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+
+const props = defineProps({
+  isOpen:         { type: Boolean, required: true },
+  selectedOrders: { type: Array,   default: () => [] },
+})
+
+const emit = defineEmits(['confirm', 'cancel'])
+
+const includeCsv = ref(true)
+
+const carrierSummary = computed(() => {
+  const carriers = [...new Set(props.selectedOrders.map(o => o.carrier))]
+  return carriers.join(' / ')
+})
+
+function handleConfirm() {
+  if (!props.selectedOrders.length) return
+  emit('confirm', {
+    orderIds:   props.selectedOrders.map(o => o.id),
+    includeCsv: includeCsv.value,
+  })
+}
+</script>
+
+<template>
+  <BaseModal
+    title="일괄 출고 확정"
+    :isOpen="isOpen"
+    width="600px"
+    @cancel="$emit('cancel')"
+  >
+    <!-- 히어로 -->
+    <div class="hero">
+      <div class="hero-top">
+        <div>
+          <div class="eyebrow">Outbound Finalization</div>
+          <div class="hero-title">{{ selectedOrders.length }}건 일괄 출고 확정</div>
+          <div class="hero-copy">송장 발행 완료 주문을 한 번에 확정합니다. 확정 시 재고 차감, 셀러 화면 반영, 외부 채널용 CSV 준비가 동시에 진행됩니다.</div>
+        </div>
+        <span class="badge badge--amber">최종 차감 대기</span>
+      </div>
+      <div class="metric-grid">
+        <div class="metric-card">
+          <span class="metric-label">대상 주문</span>
+          <span class="metric-value">{{ selectedOrders.length }}건</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">배송사</span>
+          <span class="metric-value">{{ carrierSummary || '-' }}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-label">CSV 준비</span>
+          <span class="metric-value">{{ includeCsv ? '활성' : '비활성' }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- 선택 주문 목록 -->
+    <div class="table-wrap">
+      <table class="confirm-table">
+        <thead>
+          <tr>
+            <th>주문번호</th>
+            <th>배송사</th>
+            <th>송장번호</th>
+            <th class="col-status">상태</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="o in selectedOrders" :key="o.id">
+            <td class="mono">{{ o.id }}</td>
+            <td><StatusBadge :status="o.carrier" type="carrier" /></td>
+            <td class="mono tracking">{{ o.trackingNumber }}</td>
+            <td><StatusBadge :status="o.status" type="outboundConfirm" /></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- 안내 callout -->
+    <div class="callout callout--info">
+      <div class="callout-title">출고 확정 후</div>
+      <div class="callout-copy">Amazon 외 채널 주문은 송장 CSV 다운로드 대상에 자동 포함됩니다.</div>
+    </div>
+
+    <template #footer>
+      <div class="footer-row">
+        <label class="csv-check">
+          <input v-model="includeCsv" type="checkbox" />
+          <span>Amazon 외 채널 송장 CSV 준비</span>
+        </label>
+        <div class="footer-actions">
+          <button class="ui-btn ui-btn--ghost" @click="$emit('cancel')">취소</button>
+          <button
+            class="ui-btn ui-btn--primary"
+            :disabled="!selectedOrders.length"
+            @click="handleConfirm"
+          >
+            확정
+          </button>
+        </div>
+      </div>
+    </template>
+  </BaseModal>
+</template>
+
+<style scoped>
+/* ── 히어로 ────────────────────────────────────── */
+.hero {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.hero-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.eyebrow {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--blue);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-1);
+}
+
+.hero-title {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--t1);
+  margin-bottom: var(--space-1);
+}
+
+.hero-copy {
+  font-size: var(--font-size-xs);
+  color: var(--t3);
+  line-height: 1.5;
+}
+
+/* ── 메트릭 카드 ─────────────────────────────── */
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+}
+
+.metric-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.metric-label { font-size: var(--font-size-xs); color: var(--t3); }
+.metric-value {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--t1);
+}
+
+/* ── 테이블 ─────────────────────────────────── */
+.table-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin-bottom: var(--space-4);
+}
+
+.confirm-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+}
+
+.confirm-table th {
+  padding: 8px 12px;
+  background: var(--surface-2);
+  color: var(--t3);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.confirm-table td {
+  padding: 8px 12px;
+  color: var(--t1);
+  border-bottom: 1px solid var(--border);
+}
+
+.confirm-table tr:last-child td { border-bottom: none; }
+
+.col-status { width: 110px; }
+.mono       { font-family: var(--font-mono); font-size: var(--font-size-xs); color: var(--blue); }
+.tracking   { color: var(--t3); }
+
+/* ── callout ────────────────────────────────── */
+.callout {
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-2);
+}
+
+.callout--info {
+  background: var(--blue-pale);
+  border: 1px solid var(--blue);
+}
+
+.callout-title {
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  color: var(--blue);
+  margin-bottom: var(--space-1);
+}
+
+.callout-copy {
+  font-size: var(--font-size-xs);
+  color: var(--t2);
+  line-height: 1.5;
+}
+
+/* ── 배지 ────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.badge--amber { background: var(--amber-pale); color: #b45309; }
+
+/* ── Footer ──────────────────────────────── */
+.footer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: var(--space-3);
+}
+
+.footer-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.csv-check {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--t2);
+  cursor: pointer;
+}
+
+.ui-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-4);
+  height: 36px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.ui-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.ui-btn--primary { background: var(--blue); color: #fff; }
+.ui-btn--primary:not(:disabled):hover { opacity: 0.9; }
+.ui-btn--ghost { border-color: var(--border); background: transparent; color: var(--t2); }
+.ui-btn--ghost:hover { background: var(--surface-2); color: var(--t1); }
+</style>

--- a/src/components/whManager/LabelPrintModal.vue
+++ b/src/components/whManager/LabelPrintModal.vue
@@ -1,0 +1,270 @@
+<script setup>
+import { ref, watch } from 'vue'
+import BaseModal from '@/components/common/BaseModal.vue'
+import BaseForm from '@/components/common/BaseForm.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+
+const props = defineProps({
+  isOpen: { type: Boolean, required: true },
+  order:  { type: Object,  default: null  },
+})
+
+const emit = defineEmits(['confirm', 'cancel'])
+
+const SERVICES = {
+  USPS:  ['Priority Mail', 'First Class', 'Ground Advantage'],
+  UPS:   ['Ground', 'UPS 2nd Day Air', 'UPS Next Day Air'],
+  FedEx: ['Home Delivery', 'Ground', 'Express Saver'],
+}
+
+const form = ref({ carrier: '', service: '', labelFormat: '4x6 PDF' })
+
+watch(() => props.order, (o) => {
+  if (!o) return
+  form.value.carrier     = o.recommendedCarrier
+  form.value.service     = o.recommendedService
+  form.value.labelFormat = '4x6 PDF'
+}, { immediate: true })
+
+watch(() => form.value.carrier, (carrier) => {
+  form.value.service = SERVICES[carrier]?.[0] ?? ''
+})
+
+function handleConfirm() {
+  emit('confirm', {
+    orderId:     props.order.id,
+    carrier:     form.value.carrier,
+    service:     form.value.service,
+    labelFormat: form.value.labelFormat,
+  })
+}
+</script>
+
+<template>
+  <BaseModal
+    title="배송 라벨 발행"
+    :isOpen="isOpen"
+    width="560px"
+    @cancel="$emit('cancel')"
+  >
+    <template v-if="order">
+      <!-- 히어로 -->
+      <div class="hero">
+        <div class="hero-top">
+          <div>
+            <div class="eyebrow">Label Issuance</div>
+            <div class="hero-title">{{ order.id }} 배송 라벨 발행</div>
+            <div class="hero-copy">추천 배송사, 예상 요금, 출력 형식을 확인한 뒤 라벨을 발행합니다. 발행 직후 출고 확정 단계로 이어집니다.</div>
+          </div>
+          <StatusBadge :status="order.recommendedCarrier" type="carrier" />
+        </div>
+        <div class="metric-grid">
+          <div class="metric-card">
+            <span class="metric-label">추천 배송사</span>
+            <span class="metric-value">{{ order.recommendedCarrier }}</span>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">예상 요금</span>
+            <span class="metric-value">${{ order.estimatedRate.toFixed(2) }}</span>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">출력 형식</span>
+            <span class="metric-value">4x6 PDF</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 폼 -->
+      <div class="form-surface">
+        <div class="form-grid">
+          <BaseForm label="배송사">
+            <select v-model="form.carrier" class="form-select">
+              <option v-for="c in Object.keys(SERVICES)" :key="c" :value="c">{{ c }}</option>
+            </select>
+          </BaseForm>
+          <BaseForm label="서비스">
+            <select v-model="form.service" class="form-select">
+              <option v-for="s in (SERVICES[form.carrier] ?? [])" :key="s" :value="s">{{ s }}</option>
+            </select>
+          </BaseForm>
+          <BaseForm label="예상 요금">
+            <input class="form-input" :value="`$${order.estimatedRate.toFixed(2)}`" readonly />
+          </BaseForm>
+          <BaseForm label="출력 형식">
+            <select v-model="form.labelFormat" class="form-select">
+              <option value="4x6 PDF">4x6 PDF</option>
+              <option value="ZPL">ZPL</option>
+            </select>
+          </BaseForm>
+        </div>
+      </div>
+
+      <!-- 안내 -->
+      <div class="callout callout--info">
+        <div class="callout-title">발행 후 상태 변경</div>
+        <div class="callout-copy">주문 상태가 라벨 발행 완료로 갱신되고, 출고 확정 화면에서 최종 재고 차감을 진행할 수 있습니다.</div>
+      </div>
+    </template>
+
+    <template #footer>
+      <div class="footer-row">
+        <button class="ui-btn ui-btn--ghost" @click="$emit('cancel')">닫기</button>
+        <button class="ui-btn ui-btn--primary" @click="handleConfirm">라벨 발행</button>
+      </div>
+    </template>
+  </BaseModal>
+</template>
+
+<style scoped>
+/* ── 히어로 ────────────────────────────────────── */
+.hero {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.hero-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.eyebrow {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--blue);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-1);
+}
+
+.hero-title {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--t1);
+  margin-bottom: var(--space-1);
+}
+
+.hero-copy {
+  font-size: var(--font-size-xs);
+  color: var(--t3);
+  line-height: 1.5;
+}
+
+/* ── 메트릭 카드 ─────────────────────────────── */
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+}
+
+.metric-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.metric-label {
+  font-size: var(--font-size-xs);
+  color: var(--t3);
+}
+
+.metric-value {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--t1);
+}
+
+/* ── 폼 ─────────────────────────────────────── */
+.form-surface {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+
+.form-select,
+.form-input {
+  width: 100%;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--t1);
+  font-size: var(--font-size-sm);
+}
+
+.form-input[readonly] {
+  background: var(--surface-2);
+  color: var(--t2);
+  cursor: default;
+}
+
+/* ── 안내 callout ─────────────────────────── */
+.callout {
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-2);
+}
+
+.callout--info {
+  background: var(--blue-pale);
+  border: 1px solid var(--blue);
+}
+
+.callout-title {
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  color: var(--blue);
+  margin-bottom: var(--space-1);
+}
+
+.callout-copy {
+  font-size: var(--font-size-xs);
+  color: var(--t2);
+  line-height: 1.5;
+}
+
+/* ── Footer ──────────────────────────────── */
+.footer-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.ui-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-4);
+  height: 36px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.ui-btn--primary { background: var(--blue); color: #fff; }
+.ui-btn--primary:hover { opacity: 0.9; }
+.ui-btn--ghost { border-color: var(--border); background: transparent; color: var(--t2); }
+.ui-btn--ghost:hover { background: var(--surface-2); color: var(--t1); }
+</style>

--- a/src/components/whManager/SingleOutboundConfirmModal.vue
+++ b/src/components/whManager/SingleOutboundConfirmModal.vue
@@ -1,0 +1,167 @@
+<script setup>
+import BaseModal from '@/components/common/BaseModal.vue'
+
+const props = defineProps({
+  isOpen: { type: Boolean, required: true },
+  order:  { type: Object,  default: null  },
+})
+
+const emit = defineEmits(['confirm', 'cancel'])
+
+function handleConfirm() {
+  if (!props.order) return
+  emit('confirm', { orderId: props.order.id })
+}
+</script>
+
+<template>
+  <BaseModal
+    title="개별 출고 확정"
+    :isOpen="isOpen"
+    @cancel="$emit('cancel')"
+  >
+    <template v-if="order">
+      <!-- 히어로 -->
+      <div class="hero">
+        <div class="hero-top">
+          <div>
+            <div class="eyebrow">Single Confirm</div>
+            <div class="hero-title">{{ order.id }} 출고 확정</div>
+            <div class="hero-copy">
+              송장번호 <span class="mono">{{ order.trackingNumber }}</span>
+              이 셀러 화면과 외부 채널 연동 대상에 반영됩니다.
+            </div>
+          </div>
+          <span class="badge badge--amber">재고 차감 예정</span>
+        </div>
+      </div>
+
+      <!-- 재고 차감 경고 -->
+      <div class="callout callout--warning">
+        <div class="callout-title">재고 차감 예정</div>
+        <div class="callout-copy">
+          <span v-for="(d, i) in order.skuDeductions" :key="d.sku">
+            {{ d.sku }} {{ d.qty }}EA{{ i < order.skuDeductions.length - 1 ? ' / ' : '' }}
+          </span>
+        </div>
+      </div>
+    </template>
+
+    <template #footer>
+      <div class="footer-row">
+        <button class="ui-btn ui-btn--ghost" @click="$emit('cancel')">취소</button>
+        <button class="ui-btn ui-btn--primary" :disabled="!order" @click="handleConfirm">확정</button>
+      </div>
+    </template>
+  </BaseModal>
+</template>
+
+<style scoped>
+/* ── 히어로 ────────────────────────────────────── */
+.hero {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.hero-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.eyebrow {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--blue);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-1);
+}
+
+.hero-title {
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--t1);
+  margin-bottom: var(--space-1);
+}
+
+.hero-copy {
+  font-size: var(--font-size-xs);
+  color: var(--t3);
+  line-height: 1.5;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--t2);
+}
+
+/* ── 배지 ────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.badge--amber { background: var(--amber-pale); color: #b45309; }
+
+/* ── callout ────────────────────────────── */
+.callout {
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+}
+
+.callout--warning {
+  background: var(--amber-pale);
+  border: 1px solid #d97706;
+}
+
+.callout-title {
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  color: #b45309;
+  margin-bottom: var(--space-1);
+}
+
+.callout-copy {
+  font-size: var(--font-size-xs);
+  color: var(--t2);
+  line-height: 1.5;
+}
+
+/* ── Footer ──────────────────────────────── */
+.footer-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.ui-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-4);
+  height: 36px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.ui-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.ui-btn--primary { background: var(--blue); color: #fff; }
+.ui-btn--primary:not(:disabled):hover { opacity: 0.9; }
+.ui-btn--ghost { border-color: var(--border); background: transparent; color: var(--t2); }
+.ui-btn--ghost:hover { background: var(--surface-2); color: var(--t1); }
+</style>

--- a/src/constants/status.js
+++ b/src/constants/status.js
@@ -112,6 +112,40 @@ export const WORKER_STATUS = {
 }
 
 /**
+ * OUTBOUND_CONFIRM_STATUS — 출고 확정 상태 2단계
+ *
+ * 상태 전이 흐름:
+ *
+ *   PENDING_CONFIRM → CONFIRMED
+ *
+ * PENDING_CONFIRM: 인계 완료 (택배사 인계 후 출고 확정 대기)
+ * CONFIRMED:       출고 확정 완료 (최종 재고 차감 완료)
+ *
+ * StatusBadge.vue의 MAP.outboundConfirm와 연동됨.
+ */
+export const OUTBOUND_CONFIRM_STATUS = {
+  PENDING_CONFIRM: 'PENDING_CONFIRM', // 인계 완료
+  CONFIRMED:       'CONFIRMED',       // 출고 확정 완료
+}
+
+/**
+ * LABEL_STATUS — 배송 라벨 발행 상태 2단계
+ *
+ * 상태 전이 흐름:
+ *
+ *   NOT_ISSUED → ISSUED
+ *
+ * NOT_ISSUED: 라벨 미발행 (포장 완료 후 초기 상태)
+ * ISSUED:     라벨 발행 완료
+ *
+ * StatusBadge.vue의 MAP.labelStatus와 연동됨.
+ */
+export const LABEL_STATUS = {
+  NOT_ISSUED: 'NOT_ISSUED', // 라벨 미발행
+  ISSUED:     'ISSUED',     // 라벨 발행 완료
+}
+
+/**
  * PICKING_LIST_STATUS — 피킹 리스트 상태 3단계
  *
  * 상태 전이 흐름:

--- a/src/router/routes/whManager.js
+++ b/src/router/routes/whManager.js
@@ -37,4 +37,16 @@ export default [
     component: () => import('@/views/whManager/PickingListView.vue'),
     meta: { role: ROLES.WH_MANAGER },
   },
+  {
+    path: '/whm/label-print',
+    name: ROUTE_NAMES.WH_MANAGER_LABEL_PRINT,
+    component: () => import('@/views/whManager/InvoiceView.vue'),
+    meta: { role: ROLES.WH_MANAGER },
+  },
+  {
+    path: '/whm/outbound/confirm',
+    name: ROUTE_NAMES.WH_MANAGER_OUTBOUND_CONFIRM,
+    component: () => import('@/views/whManager/OutboundConfirmView.vue'),
+    meta: { role: ROLES.WH_MANAGER },
+  },
 ]

--- a/src/views/whManager/InvoiceView.vue
+++ b/src/views/whManager/InvoiceView.vue
@@ -1,0 +1,459 @@
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import BaseTable from '@/components/common/BaseTable.vue'
+import ToastMessage from '@/components/common/ToastMessage.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import LabelPrintModal from '@/components/whManager/LabelPrintModal.vue'
+import BulkLabelModal from '@/components/whManager/BulkLabelModal.vue'
+import { getWhmInvoiceOrders, issueLabel, bulkIssueLabels } from '@/api/wh-manager'
+import { LABEL_STATUS } from '@/constants'
+
+// ── 데이터
+const orders  = ref([])
+const loading = ref(false)
+
+// ── 필터
+const filterSeller  = ref('')
+const filterCarrier = ref('')
+
+// ── 페이지네이션
+const currentPage = ref(1)
+const PAGE_SIZE   = 8
+
+// ── 체크박스 선택
+const selectedIds = ref(new Set())
+
+// ── 모달
+const showLabelModal = ref(false)
+const showBulkModal  = ref(false)
+const targetOrder    = ref(null)
+
+// ── 토스트
+const toast = ref({ visible: false, message: '', type: 'success' })
+function showToast(message, type = 'success') {
+  toast.value = { visible: true, message, type }
+}
+
+async function fetchOrders() {
+  loading.value = true
+  try {
+    const { data } = await getWhmInvoiceOrders()
+    orders.value = data
+  } catch (e) {
+    console.error('송장 발행 목록 로드 실패:', e)
+    showToast('목록을 불러오지 못했습니다.', 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchOrders)
+
+// 필터 바뀌면 1페이지·선택 초기화
+watch([filterSeller, filterCarrier], () => {
+  currentPage.value = 1
+  selectedIds.value = new Set()
+})
+
+// ── 셀러 목록 (중복 제거)
+const sellerOptions = computed(() =>
+  [...new Set(orders.value.map(o => o.sellerName))],
+)
+
+// ── 클라이언트 필터링
+const filtered = computed(() => {
+  let list = orders.value
+  if (filterSeller.value)  list = list.filter(o => o.sellerName === filterSeller.value)
+  if (filterCarrier.value) list = list.filter(o => o.recommendedCarrier === filterCarrier.value)
+  return list
+})
+
+// ── 페이지네이션
+const paged = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filtered.value.slice(start, start + PAGE_SIZE)
+})
+
+const pagination = computed(() => ({
+  page:     currentPage.value,
+  pageSize: PAGE_SIZE,
+  total:    filtered.value.length,
+}))
+
+// ── 미발행 주문만 선택 가능
+const selectableIds = computed(() =>
+  paged.value
+    .filter(o => o.labelStatus === LABEL_STATUS.NOT_ISSUED)
+    .map(o => o.id),
+)
+
+const isAllChecked = computed(() =>
+  selectableIds.value.length > 0 &&
+  selectableIds.value.every(id => selectedIds.value.has(id)),
+)
+
+const isIndeterminate = computed(() =>
+  selectableIds.value.some(id => selectedIds.value.has(id)) && !isAllChecked.value,
+)
+
+function toggleAll(e) {
+  if (e.target.checked) {
+    selectableIds.value.forEach(id => selectedIds.value.add(id))
+  } else {
+    selectableIds.value.forEach(id => selectedIds.value.delete(id))
+  }
+  selectedIds.value = new Set(selectedIds.value)
+}
+
+function toggleRow(id) {
+  if (selectedIds.value.has(id)) selectedIds.value.delete(id)
+  else selectedIds.value.add(id)
+  selectedIds.value = new Set(selectedIds.value)
+}
+
+// ── 선택된 주문 객체 목록
+const selectedOrders = computed(() =>
+  orders.value.filter(o => selectedIds.value.has(o.id)),
+)
+
+// ── 개별 라벨 발행
+function openLabelModal(order) {
+  targetOrder.value = order
+  showLabelModal.value = true
+}
+
+async function handleLabelConfirm(payload) {
+  try {
+    await issueLabel(payload.orderId, {
+      labelStatus:     LABEL_STATUS.ISSUED,
+      carrier:         payload.carrier,
+      service:         payload.service,
+      labelFormat:     payload.labelFormat,
+      labelIssuedAt:   new Date().toISOString().slice(0, 10),
+    })
+    orders.value = orders.value.map(o =>
+      o.id === payload.orderId ? { ...o, labelStatus: LABEL_STATUS.ISSUED } : o,
+    )
+    selectedIds.value.delete(payload.orderId)
+    selectedIds.value = new Set(selectedIds.value)
+    showLabelModal.value = false
+    showToast(`${payload.orderId} 라벨이 발행되었습니다.`)
+  } catch (e) {
+    showToast('라벨 발행 중 오류가 발생했습니다.', 'error')
+  }
+}
+
+// ── 일괄 라벨 출력
+async function handleBulkConfirm() {
+  const ids = [...selectedIds.value]
+  try {
+    await bulkIssueLabels({ orderIds: ids })
+    orders.value = orders.value.map(o =>
+      ids.includes(o.id) ? { ...o, labelStatus: LABEL_STATUS.ISSUED } : o,
+    )
+    selectedIds.value = new Set()
+    showBulkModal.value = false
+    showToast(`${ids.length}건 라벨이 일괄 발행되었습니다.`)
+  } catch (e) {
+    showToast('일괄 라벨 발행 중 오류가 발생했습니다.', 'error')
+  }
+}
+
+// ── 컬럼 정의
+const columns = [
+  { key: 'checkbox',            label: '',          width: '44px',  align: 'center' },
+  { key: 'id',                  label: '주문번호',   width: '170px' },
+  { key: 'sellerName',          label: '셀러' },
+  { key: 'itemSummary',         label: '상품 / 중량' },
+  { key: 'shipDestination',     label: '배송지',     width: '90px'  },
+  { key: 'recommendedCarrier',  label: '추천 배송사', width: '110px', align: 'center' },
+  { key: 'estimatedRate',       label: '예상 요금',  width: '100px', align: 'right'  },
+  { key: 'labelStatus',         label: '상태',       width: '130px', align: 'center' },
+  { key: 'actions',             label: '작업',       width: '90px',  align: 'center' },
+]
+
+const breadcrumb = [
+  { label: 'CONK' },
+  { label: '출고 관리' },
+  { label: '송장 발행' },
+]
+</script>
+
+<template>
+  <AppLayout title="송장 발행" :breadcrumb="breadcrumb" :loading="loading">
+
+    <!-- ── 상단 액션 ───────────────────────────────── -->
+    <template #header-action>
+      <button
+        class="ui-btn ui-btn--primary"
+        :disabled="selectedIds.size === 0"
+        @click="showBulkModal = true"
+      >
+        <svg viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.8" width="13" height="13">
+          <rect x="1" y="2" width="11" height="9" rx="1"/>
+          <path d="M4 7h5M4 9h3" stroke-linecap="round"/>
+        </svg>
+        일괄 라벨 출력
+      </button>
+    </template>
+
+    <!-- ── 안내 배너 ──────────────────────────────── -->
+    <div class="info-banner">
+      <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <circle cx="7" cy="7" r="5.5"/>
+        <path d="M7 5v4M7 3.5v.5" stroke-linecap="round"/>
+      </svg>
+      <p>포장 완료된 주문에 대해 USPS·UPS·FedEx 요금을 비교하여 최적 배송사를 선택하고 라벨을 출력합니다.</p>
+    </div>
+
+    <!-- ── 카드 ───────────────────────────────────── -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-title-wrap">
+          <span class="card-title">포장 완료 — 송장 발행 대기</span>
+          <span class="badge badge--amber">{{ orders.filter(o => o.labelStatus === LABEL_STATUS.NOT_ISSUED).length }}건 대기</span>
+        </div>
+        <span v-if="selectedIds.size > 0" class="selected-info">
+          <strong>{{ selectedIds.size }}</strong>건 선택됨
+        </span>
+      </div>
+
+      <!-- 필터 바 -->
+      <div class="filter-bar">
+        <select v-model="filterSeller" class="select-filter">
+          <option value="">전체 셀러</option>
+          <option v-for="s in sellerOptions" :key="s" :value="s">{{ s }}</option>
+        </select>
+        <select v-model="filterCarrier" class="select-filter">
+          <option value="">전체 배송사</option>
+          <option value="USPS">USPS</option>
+          <option value="UPS">UPS</option>
+          <option value="FedEx">FedEx</option>
+        </select>
+      </div>
+
+      <!-- 테이블 -->
+      <div class="table-section">
+        <BaseTable
+          :columns="columns"
+          :rows="paged"
+          :loading="loading"
+          :pagination="pagination"
+          row-key="id"
+          @page-change="p => currentPage = p"
+        >
+          <!-- 헤더: 전체 선택 -->
+          <template #header-checkbox>
+            <input
+              type="checkbox"
+              :checked="isAllChecked"
+              :indeterminate="isIndeterminate"
+              @change="toggleAll"
+            />
+          </template>
+
+          <!-- 체크박스 -->
+          <template #cell-checkbox="{ row }">
+            <input
+              type="checkbox"
+              :checked="selectedIds.has(row.id)"
+              :disabled="row.labelStatus === LABEL_STATUS.ISSUED"
+              @change="toggleRow(row.id)"
+            />
+          </template>
+
+          <!-- 주문번호 -->
+          <template #cell-id="{ row }">
+            <span class="mono order-id">{{ row.id }}</span>
+          </template>
+
+          <!-- 상품 / 중량 -->
+          <template #cell-itemSummary="{ row }">
+            {{ row.itemSummary }} / {{ row.weightLbs }} lbs
+          </template>
+
+          <!-- 배송지 -->
+          <template #cell-shipDestination="{ row }">
+            <span class="text-muted">{{ row.shipState }}, {{ row.shipCountry }}</span>
+          </template>
+
+          <!-- 추천 배송사 -->
+          <template #cell-recommendedCarrier="{ row }">
+            <StatusBadge :status="row.recommendedCarrier" type="carrier" />
+          </template>
+
+          <!-- 예상 요금 -->
+          <template #cell-estimatedRate="{ row }">
+            <span class="rate">${{ row.estimatedRate.toFixed(2) }}</span>
+          </template>
+
+          <!-- 상태 배지 -->
+          <template #cell-labelStatus="{ row }">
+            <StatusBadge :status="row.labelStatus" type="labelStatus" />
+          </template>
+
+          <!-- 작업 -->
+          <template #cell-actions="{ row }">
+            <button
+              v-if="row.labelStatus === LABEL_STATUS.NOT_ISSUED"
+              class="ui-btn ui-btn--primary ui-btn--sm"
+              @click="openLabelModal(row)"
+            >
+              라벨 발행
+            </button>
+            <button
+              v-else
+              class="ui-btn ui-btn--ghost ui-btn--sm"
+              @click="openLabelModal(row)"
+            >
+              재출력
+            </button>
+          </template>
+        </BaseTable>
+      </div>
+    </div>
+
+    <!-- ── 모달 ──────────────────────────────────── -->
+    <LabelPrintModal
+      :isOpen="showLabelModal"
+      :order="targetOrder"
+      @confirm="handleLabelConfirm"
+      @cancel="showLabelModal = false"
+    />
+
+    <BulkLabelModal
+      :isOpen="showBulkModal"
+      :selectedOrders="selectedOrders"
+      @confirm="handleBulkConfirm"
+      @cancel="showBulkModal = false"
+    />
+
+    <!-- ── 토스트 ─────────────────────────────────── -->
+    <ToastMessage
+      v-model:visible="toast.visible"
+      :message="toast.message"
+      :type="toast.type"
+    />
+  </AppLayout>
+</template>
+
+<style scoped>
+/* ── 안내 배너 ─────────────────────────────────── */
+.info-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background: var(--blue-pale);
+  border: 1px solid var(--blue);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-4);
+  font-size: var(--font-size-sm);
+  color: var(--t2);
+  line-height: 1.5;
+}
+
+.info-banner svg { flex-shrink: 0; margin-top: 2px; color: var(--blue); }
+.info-banner p   { margin: 0; }
+
+/* ── 카드 ──────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.card-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.card-title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--t1);
+}
+
+.selected-info {
+  font-size: var(--font-size-sm);
+  color: var(--t3);
+}
+
+/* ── 필터 바 ────────────────────────────────────── */
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+.select-filter {
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--t1);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+/* ── 테이블 ────────────────────────────────────── */
+.table-section { padding: var(--space-4); }
+
+/* ── 셀 헬퍼 ────────────────────────────────────── */
+.mono      { font-family: var(--font-mono); font-size: var(--font-size-xs); }
+.order-id  { color: var(--blue); }
+.text-muted { color: var(--t3); }
+.rate      { font-weight: 700; color: var(--green); }
+
+/* ── 배지 ──────────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.badge--amber { background: var(--amber-pale); color: #b45309; }
+
+/* ── 버튼 ──────────────────────────────────────── */
+.ui-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  height: 36px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background var(--ease-fast), opacity var(--ease-fast);
+}
+
+.ui-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.ui-btn--primary { background: var(--blue); color: #fff; }
+.ui-btn--primary:not(:disabled):hover { opacity: 0.9; }
+
+.ui-btn--ghost { border-color: var(--border); background: transparent; color: var(--t2); }
+.ui-btn--ghost:not(:disabled):hover { background: var(--surface-2); color: var(--t1); }
+
+.ui-btn--sm { height: 28px; font-size: var(--font-size-xs); }
+</style>

--- a/src/views/whManager/OutboundConfirmView.vue
+++ b/src/views/whManager/OutboundConfirmView.vue
@@ -1,0 +1,502 @@
+<script setup>
+import { ref, computed, watch, onMounted } from 'vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import BaseTable from '@/components/common/BaseTable.vue'
+import ToastMessage from '@/components/common/ToastMessage.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import SingleOutboundConfirmModal from '@/components/whManager/SingleOutboundConfirmModal.vue'
+import BulkOutboundConfirmModal from '@/components/whManager/BulkOutboundConfirmModal.vue'
+import { getWhmOutboundConfirmOrders, confirmSingleOutbound, bulkConfirmOutbound } from '@/api/wh-manager'
+import { OUTBOUND_CONFIRM_STATUS } from '@/constants'
+
+// ── 데이터
+const orders  = ref([])
+const loading = ref(false)
+
+// ── 필터
+const searchText    = ref('')
+const filterSeller  = ref('')
+const filterCarrier = ref('')
+
+// ── 페이지네이션
+const currentPage = ref(1)
+const PAGE_SIZE   = 8
+
+// ── 체크박스 선택
+const selectedIds = ref(new Set())
+
+// ── 모달
+const showSingleModal = ref(false)
+const showBulkModal   = ref(false)
+const targetOrder     = ref(null)
+
+// ── 토스트
+const toast = ref({ visible: false, message: '', type: 'success' })
+function showToast(message, type = 'success') {
+  toast.value = { visible: true, message, type }
+}
+
+async function fetchOrders() {
+  loading.value = true
+  try {
+    const { data } = await getWhmOutboundConfirmOrders()
+    orders.value = data
+  } catch (e) {
+    console.error('출고 확정 목록 로드 실패:', e)
+    showToast('목록을 불러오지 못했습니다.', 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(fetchOrders)
+
+watch([searchText, filterSeller, filterCarrier], () => {
+  currentPage.value = 1
+  selectedIds.value = new Set()
+})
+
+// ── 셀러 목록 (중복 제거)
+const sellerOptions = computed(() =>
+  [...new Set(orders.value.map(o => o.sellerName))],
+)
+
+// ── 클라이언트 필터링
+const filtered = computed(() => {
+  let list = orders.value
+  if (filterSeller.value)  list = list.filter(o => o.sellerName === filterSeller.value)
+  if (filterCarrier.value) list = list.filter(o => o.carrier === filterCarrier.value)
+  if (searchText.value) {
+    const q = searchText.value.toLowerCase()
+    list = list.filter(o =>
+      o.id.toLowerCase().includes(q) ||
+      o.trackingNumber.toLowerCase().includes(q),
+    )
+  }
+  return list
+})
+
+// ── 페이지네이션
+const paged = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filtered.value.slice(start, start + PAGE_SIZE)
+})
+
+const pagination = computed(() => ({
+  page:     currentPage.value,
+  pageSize: PAGE_SIZE,
+  total:    filtered.value.length,
+}))
+
+// ── 확정 대기 주문만 선택 가능
+const selectableIds = computed(() =>
+  paged.value
+    .filter(o => o.status === OUTBOUND_CONFIRM_STATUS.PENDING_CONFIRM)
+    .map(o => o.id),
+)
+
+const isAllChecked = computed(() =>
+  selectableIds.value.length > 0 &&
+  selectableIds.value.every(id => selectedIds.value.has(id)),
+)
+
+const isIndeterminate = computed(() =>
+  selectableIds.value.some(id => selectedIds.value.has(id)) && !isAllChecked.value,
+)
+
+function toggleAll(e) {
+  if (e.target.checked) {
+    selectableIds.value.forEach(id => selectedIds.value.add(id))
+  } else {
+    selectableIds.value.forEach(id => selectedIds.value.delete(id))
+  }
+  selectedIds.value = new Set(selectedIds.value)
+}
+
+function toggleRow(id) {
+  if (selectedIds.value.has(id)) selectedIds.value.delete(id)
+  else selectedIds.value.add(id)
+  selectedIds.value = new Set(selectedIds.value)
+}
+
+const selectedOrders = computed(() =>
+  orders.value.filter(o => selectedIds.value.has(o.id)),
+)
+
+// ── 개별 출고 확정
+function openSingleModal(order) {
+  targetOrder.value = order
+  showSingleModal.value = true
+}
+
+async function handleSingleConfirm(payload) {
+  try {
+    await confirmSingleOutbound(payload.orderId, { status: OUTBOUND_CONFIRM_STATUS.CONFIRMED })
+    orders.value = orders.value.map(o =>
+      o.id === payload.orderId ? { ...o, status: OUTBOUND_CONFIRM_STATUS.CONFIRMED } : o,
+    )
+    selectedIds.value.delete(payload.orderId)
+    selectedIds.value = new Set(selectedIds.value)
+    showSingleModal.value = false
+    showToast(`${payload.orderId} 출고 확정이 완료되었습니다.`)
+  } catch (e) {
+    showToast('출고 확정 처리 중 오류가 발생했습니다.', 'error')
+  }
+}
+
+// ── 일괄 출고 확정
+async function handleBulkConfirm(payload) {
+  try {
+    await bulkConfirmOutbound(payload)
+    const ids = payload.orderIds
+    orders.value = orders.value.map(o =>
+      ids.includes(o.id) ? { ...o, status: OUTBOUND_CONFIRM_STATUS.CONFIRMED } : o,
+    )
+    selectedIds.value = new Set()
+    showBulkModal.value = false
+    showToast(`${ids.length}건 일괄 출고 확정이 완료되었습니다.`)
+  } catch (e) {
+    showToast('일괄 출고 확정 처리 중 오류가 발생했습니다.', 'error')
+  }
+}
+
+// ── 컬럼 정의
+const columns = [
+  { key: 'checkbox',       label: '',          width: '44px',  align: 'center' },
+  { key: 'id',             label: '주문번호',   width: '170px' },
+  { key: 'sellerName',     label: '셀러' },
+  { key: 'itemSummary',    label: '상품 / 수량' },
+  { key: 'carrierService', label: '배송사 / 서비스', width: '160px' },
+  { key: 'trackingNumber', label: '송장번호',   width: '170px' },
+  { key: 'shipState',      label: '배송지',     width: '80px'  },
+  { key: 'labelIssuedAt',  label: '라벨 발행일', width: '100px', align: 'center' },
+  { key: 'status',         label: '상태',       width: '120px', align: 'center' },
+  { key: 'actions',        label: '작업',       width: '90px',  align: 'center' },
+]
+
+const breadcrumb = [
+  { label: 'CONK' },
+  { label: '출고 관리' },
+  { label: '출고 확정' },
+]
+</script>
+
+<template>
+  <AppLayout title="출고 확정" :breadcrumb="breadcrumb" :loading="loading">
+
+    <!-- ── 상단 액션 ───────────────────────────────── -->
+    <template #header-action>
+      <button
+        class="ui-btn ui-btn--primary"
+        :disabled="selectedIds.size === 0"
+        @click="showBulkModal = true"
+      >
+        <svg viewBox="0 0 13 13" fill="none" stroke="currentColor" stroke-width="1.8" width="13" height="13">
+          <path d="M2 6.5l3 3 6-6" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        일괄 출고 확정
+      </button>
+    </template>
+
+    <!-- ── 안내 배너 ──────────────────────────────── -->
+    <div class="info-banner">
+      <svg viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+        <circle cx="7" cy="7" r="5.5"/>
+        <path d="M7 5v4M7 3.5v.5" stroke-linecap="round"/>
+      </svg>
+      <p>라벨 발행이 완료된 주문을 수령지에 인계하고 <strong>출고 확정</strong>을 처리합니다. 확정 즉시 할당 재고가 영구 차감됩니다.</p>
+    </div>
+
+    <!-- ── 카드 ───────────────────────────────────── -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-title-wrap">
+          <span class="card-title">인계 완료 — 출고 확정 대기</span>
+          <span class="badge badge--amber">
+            {{ orders.filter(o => o.status === OUTBOUND_CONFIRM_STATUS.PENDING_CONFIRM).length }}건 대기
+          </span>
+        </div>
+        <span v-if="selectedIds.size > 0" class="selected-info">
+          <strong>{{ selectedIds.size }}</strong>건 선택됨
+        </span>
+      </div>
+
+      <!-- 필터 바 -->
+      <div class="filter-bar">
+        <div class="search-wrap">
+          <svg class="search-icon" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.6">
+            <circle cx="6.5" cy="6.5" r="4"/>
+            <path d="M10 10l3 3" stroke-linecap="round"/>
+          </svg>
+          <input
+            v-model="searchText"
+            class="search-input"
+            type="text"
+            placeholder="주문번호, 송장번호 검색..."
+          />
+        </div>
+        <select v-model="filterSeller" class="select-filter">
+          <option value="">전체 셀러</option>
+          <option v-for="s in sellerOptions" :key="s" :value="s">{{ s }}</option>
+        </select>
+        <select v-model="filterCarrier" class="select-filter">
+          <option value="">전체 배송사</option>
+          <option value="USPS">USPS</option>
+          <option value="UPS">UPS</option>
+          <option value="FedEx">FedEx</option>
+        </select>
+      </div>
+
+      <!-- 테이블 -->
+      <BaseTable
+        :columns="columns"
+        :rows="paged"
+        :loading="loading"
+        :pagination="pagination"
+        row-key="id"
+        @page-change="p => currentPage = p"
+      >
+        <!-- 헤더: 전체 선택 -->
+        <template #header-checkbox>
+          <input
+            type="checkbox"
+            :checked="isAllChecked"
+            :indeterminate="isIndeterminate"
+            @change="toggleAll"
+          />
+        </template>
+
+        <!-- 체크박스 -->
+        <template #cell-checkbox="{ row }">
+          <input
+            type="checkbox"
+            :checked="selectedIds.has(row.id)"
+            :disabled="row.status === OUTBOUND_CONFIRM_STATUS.CONFIRMED"
+            @change="toggleRow(row.id)"
+          />
+        </template>
+
+        <!-- 주문번호 -->
+        <template #cell-id="{ row }">
+          <span class="mono order-id">{{ row.id }}</span>
+        </template>
+
+        <!-- 배송사 / 서비스 -->
+        <template #cell-carrierService="{ row }">
+          <div class="carrier-cell">
+            <StatusBadge :status="row.carrier" type="carrier" />
+            <span class="text-muted">{{ row.service }}</span>
+          </div>
+        </template>
+
+        <!-- 송장번호 -->
+        <template #cell-trackingNumber="{ row }">
+          <span class="mono tracking">{{ row.trackingNumber }}</span>
+        </template>
+
+        <!-- 배송지 -->
+        <template #cell-shipState="{ row }">
+          <span class="text-muted">{{ row.shipState }}, {{ row.shipCountry }}</span>
+        </template>
+
+        <!-- 라벨 발행일 -->
+        <template #cell-labelIssuedAt="{ row }">
+          <span class="text-muted">{{ row.labelIssuedAt }}</span>
+        </template>
+
+        <!-- 상태 배지 -->
+        <template #cell-status="{ row }">
+          <StatusBadge :status="row.status" type="outboundConfirm" />
+        </template>
+
+        <!-- 작업 -->
+        <template #cell-actions="{ row }">
+          <button
+            v-if="row.status === OUTBOUND_CONFIRM_STATUS.PENDING_CONFIRM"
+            class="ui-btn ui-btn--primary ui-btn--sm"
+            @click="openSingleModal(row)"
+          >
+            출고 확정
+          </button>
+          <button
+            v-else
+            class="ui-btn ui-btn--ghost ui-btn--sm"
+            disabled
+          >
+            완료
+          </button>
+        </template>
+      </BaseTable>
+    </div>
+
+    <!-- ── 모달 ──────────────────────────────────── -->
+    <SingleOutboundConfirmModal
+      :isOpen="showSingleModal"
+      :order="targetOrder"
+      @confirm="handleSingleConfirm"
+      @cancel="showSingleModal = false"
+    />
+
+    <BulkOutboundConfirmModal
+      :isOpen="showBulkModal"
+      :selectedOrders="selectedOrders"
+      @confirm="handleBulkConfirm"
+      @cancel="showBulkModal = false"
+    />
+
+    <!-- ── 토스트 ─────────────────────────────────── -->
+    <ToastMessage
+      v-model:visible="toast.visible"
+      :message="toast.message"
+      :type="toast.type"
+    />
+  </AppLayout>
+</template>
+
+<style scoped>
+/* ── 안내 배너 ─────────────────────────────────── */
+.info-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background: var(--blue-pale);
+  border: 1px solid var(--blue);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-4);
+  font-size: var(--font-size-sm);
+  color: var(--t2);
+  line-height: 1.5;
+}
+.info-banner svg { flex-shrink: 0; margin-top: 2px; color: var(--blue); }
+.info-banner p   { margin: 0; }
+
+/* ── 카드 ──────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.card-title-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.card-title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--t1);
+}
+
+.selected-info {
+  font-size: var(--font-size-sm);
+  color: var(--t3);
+}
+
+/* ── 필터 바 ────────────────────────────────────── */
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+
+.search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-icon {
+  position: absolute;
+  left: 10px;
+  width: 14px;
+  height: 14px;
+  color: var(--t3);
+  pointer-events: none;
+}
+
+.search-input {
+  height: 36px;
+  padding: 0 12px 0 32px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--t1);
+  font-size: var(--font-size-sm);
+  width: 220px;
+  outline: none;
+  transition: border-color var(--ease-fast);
+}
+.search-input:focus { border-color: var(--blue); }
+
+.select-filter {
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--t1);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+/* ── 셀 헬퍼 ────────────────────────────────────── */
+.mono      { font-family: var(--font-mono); font-size: var(--font-size-xs); }
+.order-id  { color: var(--blue); }
+.tracking  { color: var(--t3); }
+.text-muted { color: var(--t3); font-size: var(--font-size-xs); }
+
+.carrier-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+/* ── 배지 ──────────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.badge--amber { background: var(--amber-pale); color: #b45309; }
+
+/* ── 버튼 ──────────────────────────────────────── */
+.ui-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  height: 36px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background var(--ease-fast), opacity var(--ease-fast);
+}
+
+.ui-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.ui-btn--primary { background: var(--blue); color: #fff; }
+.ui-btn--primary:not(:disabled):hover { opacity: 0.9; }
+.ui-btn--ghost { border-color: var(--border); background: transparent; color: var(--t2); }
+.ui-btn--ghost:not(:disabled):hover { background: var(--surface-2); color: var(--t1); }
+.ui-btn--sm { height: 28px; font-size: var(--font-size-xs); }
+</style>


### PR DESCRIPTION
## 📝 변경 사항
- 창고 관리자 송장 발행 및 출고 확정 페이지 구현    

## 🔍 주요 작업 내용
- [x] Frontend:
    - InvoiceView.vue — 포장 완료 주문 목록, 배송사 요금 비교, 개별/일괄 라벨 발행
    - LabelPrintModal.vue — 개별 라벨 발행 모달 (배송사·서비스·출력형식 선택)
    - BulkLabelModal.vue — 일괄 라벨 출력 모달
    - OutboundConfirmView.vue — 인계 완료 주문 목록, 개별/일괄 출고 확정
    - SingleOutboundConfirmModal.vue — 개별 출고 확정 모달 (재고 차감 내역 표시)
    - BulkOutboundConfirmModal.vue — 일괄 출고 확정 모달 (CSV 포함 옵션)
    - StatusBadge.vue — carrier / labelStatus / outboundConfirm 타입 추가
    - status.js — LABEL_STATUS, OUTBOUND_CONFIRM_STATUS 상수 추가
    - wh-manager.js (API) — 송장 발행 / 출고 확정 관련 함수 추가
    - whManager.js (router) — /whm/label-print, /whm/outbound/confirm 라우트 추가
    - whManager.js (menu) — 사이드바 '출고 관리 > 송장 발행 / 출고 확정' 메뉴 추가
    - wh-manager.json — wh_invoice_orders, wh_outbound_confirm_orders Mock 데이터 추가

## 📸 스크린샷 (선택)
### 송장발행
<img width="2558" height="1304" alt="image" src="https://github.com/user-attachments/assets/025ccd41-3afa-480a-bddd-5044731acb57" />
<img width="2559" height="1301" alt="image" src="https://github.com/user-attachments/assets/ef460507-7898-480e-b599-026340e9cb4a" />
<img width="2556" height="1301" alt="image" src="https://github.com/user-attachments/assets/53ef89cd-3bab-41eb-8ade-e27c51f1c3f1" />

### 출고확정
<img width="2557" height="1301" alt="image" src="https://github.com/user-attachments/assets/66a15926-3cba-4b0f-80dc-8547f9019075" />
<img width="2557" height="1302" alt="image" src="https://github.com/user-attachments/assets/9ff59c7f-51be-4056-b1f8-471506ce99d8" />
<img width="2558" height="1305" alt="image" src="https://github.com/user-attachments/assets/607f8a92-df5b-4ede-930a-7dc122ae56ff" />


## 💬 리뷰어에게 한마디
- 배송사(USPS/UPS/FedEx) 배지는 StatusBadge에 carrier 타입으로 통합했습니다. 하드코딩 없이 상수와 StatusBadge만으로 처리됩니다.
- 출고 확정 시 OUTBOUND_CONFIRM_STATUS 상수로 상태를 관리하며, 확정 완료된 행은 체크박스 비활성화 및 버튼 "완료" 처리됩니다.