### PR TITLE
셀러 상품 등록 UI 구현

### DIFF
--- a/src/components/layout/menus/seller.js
+++ b/src/components/layout/menus/seller.js
@@ -28,6 +28,7 @@ export const SELLER_MENU_GROUPS = [
     label: '등록',
     items: [
       { name: ROUTE_NAMES.SELLER_ORDER_REGISTER, label: '주문 등록', icon: '+' },
+      { name: ROUTE_NAMES.SELLER_PRODUCT_REGISTER, label: '상품 등록', icon: '□' },
       { name: ROUTE_NAMES.SELLER_ASN_CREATE, label: 'ASN 등록', icon: '↓' },
     ],
   },

--- a/src/router/routes/seller.js
+++ b/src/router/routes/seller.js
@@ -35,7 +35,12 @@ export default [
   // TODO(frontend): 주문 상세 라우트 추가
 
   // 상품 관리
-  // TODO(frontend): 상품 등록 라우트 추가
+  {
+    path: '/seller/products/register',
+    name: ROUTE_NAMES.SELLER_PRODUCT_REGISTER,
+    component: () => import('@/views/seller/SellerProductRegisterView.vue'),
+    meta: { role: ROLES.SELLER },
+  },
   // TODO(frontend): 상품 목록 라우트 추가
 
   // 재고 관리
@@ -48,7 +53,7 @@ export default [
     component: () => import('@/views/seller/SellerAsnCreateView.vue'),
     meta: { role: ROLES.SELLER },
   },
-    // Seller ASN 목록 화면
+  // Seller ASN 목록 화면
   {
     path: '/seller/asn/list',
     name: ROUTE_NAMES.SELLER_ASN_LIST,

--- a/src/utils/productRegister.utils.js
+++ b/src/utils/productRegister.utils.js
@@ -1,0 +1,141 @@
+/**
+ * 셀러 상품 등록 화면에서 사용하는 로컬 mock 데이터와 검증 유틸.
+ * UI 우선 단계라 저장 없이도 입력 흐름과 자동 계산을 확인할 수 있게 한다.
+ */
+
+// 상품 등록 화면에서 선택할 수 있는 카테고리 mock 옵션.
+export const SELLER_PRODUCT_CATEGORY_OPTIONS = [
+  { value: 'SKINCARE', label: '스킨케어' },
+  { value: 'SERUM', label: '세럼/앰플' },
+  { value: 'MASKPACK', label: '마스크팩' },
+  { value: 'SUNCARE', label: '선케어' },
+  { value: 'CLEANSING', label: '클렌징' },
+]
+
+// 통관 정보 영역에서 사용하는 HS 코드 mock 옵션.
+export const SELLER_PRODUCT_HS_CODE_OPTIONS = [
+  { value: '3304.99.9000', label: '3304.99.9000 - 기타 스킨케어 제품' },
+  { value: '3304.99.5000', label: '3304.99.5000 - 세럼/앰플' },
+  { value: '3307.90.0000', label: '3307.90.0000 - 마스크팩' },
+]
+
+// 원산지 선택 mock 옵션.
+export const SELLER_PRODUCT_ORIGIN_OPTIONS = [
+  { value: 'KR', label: '대한민국 (KR)' },
+  { value: 'CN', label: '중국 (CN)' },
+  { value: 'JP', label: '일본 (JP)' },
+  { value: 'US', label: '미국 (US)' },
+]
+
+// 상품 등록 폼의 초기 상태를 만든다.
+export function createInitialProductForm() {
+  return {
+    sku: '',
+    productName: '',
+    category: '',
+    brand: 'LUMIERE BEAUTY',
+    description: '',
+    salePrice: '',
+    costPrice: '',
+    weight: '',
+    length: '',
+    width: '',
+    height: '',
+    hsCode: '',
+    originCountry: '',
+    customsValue: '',
+    barcode: '',
+    asin: '',
+    isActive: true,
+    lowStockAlert: true,
+    amazonSync: false,
+    stockAlertThreshold: 10,
+    minOrderQuantity: 1,
+  }
+}
+
+// 화면에 바로 바인딩할 필드별 에러 기본값.
+export function createInitialProductErrors() {
+  return {
+    sku: '',
+    productName: '',
+    category: '',
+    salePrice: '',
+    weight: '',
+    length: '',
+    width: '',
+    height: '',
+    originCountry: '',
+    customsValue: '',
+  }
+}
+
+// 숫자 필드를 양수로만 인정한다.
+function toPositiveNumber(value) {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : 0
+}
+
+/**
+ * 길이, 너비, 높이를 기준으로 부피중량을 계산한다.
+ * 입력값이 모두 양수일 때만 고정 소수점 3자리 수치를 반환한다.
+ */
+export function buildVolumeWeight(length, width, height, divisor = 139) {
+  const normalizedLength = toPositiveNumber(length)
+  const normalizedWidth = toPositiveNumber(width)
+  const normalizedHeight = toPositiveNumber(height)
+
+  if (!normalizedLength || !normalizedWidth || !normalizedHeight) return ''
+
+  return Number(((normalizedLength * normalizedWidth * normalizedHeight) / divisor).toFixed(3))
+}
+
+/**
+ * 상품 등록 화면의 필수값을 검사한다.
+ * 현재 단계에서는 저장 대신 화면 검증과 성공 메시지 흐름만 확인한다.
+ */
+export function validateProductForm(form = {}) {
+  const errors = createInitialProductErrors()
+
+  if (!String(form.sku ?? '').trim()) {
+    errors.sku = 'SKU를 입력하세요.'
+  }
+
+  if (!String(form.productName ?? '').trim()) {
+    errors.productName = '상품명을 입력하세요.'
+  }
+
+  if (!String(form.category ?? '').trim()) {
+    errors.category = '카테고리를 선택하세요.'
+  }
+
+  if (!toPositiveNumber(form.salePrice)) {
+    errors.salePrice = '판매가는 0보다 커야 합니다.'
+  }
+
+  if (!toPositiveNumber(form.weight)) {
+    errors.weight = '중량을 입력하세요.'
+  }
+
+  if (!toPositiveNumber(form.length)) {
+    errors.length = '길이를 입력하세요.'
+  }
+
+  if (!toPositiveNumber(form.width)) {
+    errors.width = '너비를 입력하세요.'
+  }
+
+  if (!toPositiveNumber(form.height)) {
+    errors.height = '높이를 입력하세요.'
+  }
+
+  if (!String(form.originCountry ?? '').trim()) {
+    errors.originCountry = '원산지를 선택하세요.'
+  }
+
+  if (!toPositiveNumber(form.customsValue)) {
+    errors.customsValue = '신고가를 입력하세요.'
+  }
+
+  return errors
+}

--- a/src/views/seller/SellerProductRegisterView.vue
+++ b/src/views/seller/SellerProductRegisterView.vue
@@ -1,0 +1,698 @@
+<script setup>
+/**
+ * 셀러 상품 등록 화면.
+ * Pigma 상품 등록 시안을 기준으로 입력 섹션과 우측 설정 카드를 로컬 상태로 먼저 구성한다.
+ */
+import { computed, reactive, ref } from 'vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import BaseForm from '@/components/common/BaseForm.vue'
+import FileUpload from '@/components/common/FileUpload.vue'
+import {
+  buildVolumeWeight,
+  createInitialProductErrors,
+  createInitialProductForm,
+  SELLER_PRODUCT_CATEGORY_OPTIONS,
+  SELLER_PRODUCT_HS_CODE_OPTIONS,
+  SELLER_PRODUCT_ORIGIN_OPTIONS,
+  validateProductForm,
+} from '@/utils/productRegister.utils.js'
+
+const breadcrumb = [{ label: 'Seller' }, { label: '상품 등록' }]
+
+// 상품 등록 입력값과 에러를 화면에 직접 바인딩한다.
+const productForm = ref(createInitialProductForm())
+const fieldErrors = reactive(createInitialProductErrors())
+
+// 이미지 업로드는 현재 단계에서 파일명만 미리보기한다.
+const selectedImages = ref([])
+
+// 버튼 클릭 후 사용자에게 보여줄 안내 문구를 구분해서 관리한다.
+const infoMessage = ref('')
+const successMessage = ref('')
+const errorMessage = ref('')
+
+// 치수 입력이 있으면 부피중량을 자동 계산해 읽기 전용 필드에 표시한다.
+const volumeWeight = computed(() => {
+  return buildVolumeWeight(productForm.value.length, productForm.value.width, productForm.value.height)
+})
+
+// 우측 이미지 슬롯은 최대 3칸까지만 노출한다.
+const imageSlots = computed(() => {
+  return Array.from({ length: 3 }, (_, index) => selectedImages.value[index] ?? null)
+})
+
+// 화면 메시지는 한 번에 하나만 보이도록 초기화한다.
+function clearMessages() {
+  infoMessage.value = ''
+  successMessage.value = ''
+  errorMessage.value = ''
+}
+
+// 상품 등록 검증 결과를 다시 보여주기 전 기존 에러를 비운다.
+function clearFieldErrors() {
+  const nextErrors = createInitialProductErrors()
+  Object.keys(fieldErrors).forEach((key) => {
+    fieldErrors[key] = nextErrors[key]
+  })
+}
+
+// 현재 입력값과 이미지 미리보기를 초기 상태로 되돌린다.
+function resetProductForm() {
+  productForm.value = createInitialProductForm()
+  selectedImages.value = []
+  clearFieldErrors()
+}
+
+// 취소 버튼은 로컬 상태만 초기화하고 안내 메시지를 남긴다.
+function handleCancel() {
+  clearMessages()
+  resetProductForm()
+  infoMessage.value = '작성 중인 상품 입력을 초기화했습니다.'
+}
+
+// 이미지 업로드는 최대 3장까지만 화면 슬롯에 표시한다.
+function handleImageSelected(files) {
+  const targetFiles = Array.isArray(files) ? files : [files]
+
+  clearMessages()
+  selectedImages.value = targetFiles
+    .filter(Boolean)
+    .slice(0, 3)
+    .map((file, index) => ({
+      id: `product-image-${index + 1}`,
+      name: file.name,
+    }))
+
+  if (!selectedImages.value.length) return
+
+  infoMessage.value = targetFiles.length > 3
+    ? '이미지는 최대 3장까지 미리보기합니다.'
+    : `${selectedImages.value.length}장의 상품 이미지를 화면에 반영했습니다.`
+}
+
+// 토글형 판매 설정은 로컬 상태에서만 on/off 를 바꾼다.
+function handleToggle(fieldKey) {
+  productForm.value[fieldKey] = !productForm.value[fieldKey]
+}
+
+// 바코드 스캔과 HS 조회는 다음 단계 연결 예정이라 안내 메시지만 보여준다.
+function showHelperMessage(message) {
+  clearMessages()
+  infoMessage.value = message
+}
+
+// 임시저장은 실제 저장 없이 현재 상품 초안이 준비되었다는 메시지만 보여준다.
+function handleDraftSave() {
+  clearMessages()
+
+  const productLabel = productForm.value.productName || productForm.value.sku || '신규 상품'
+  // TODO(frontend): 상품 임시저장 API를 연결한다.
+  infoMessage.value = `${productLabel} 초안을 임시저장했습니다. 실제 저장은 다음 단계에서 연결합니다.`
+}
+
+// 최종 등록은 필수 입력을 검증한 뒤 성공 메시지를 보여준다.
+function handleSubmit() {
+  clearMessages()
+  clearFieldErrors()
+
+  const errors = validateProductForm(productForm.value)
+  Object.entries(errors).forEach(([key, value]) => {
+    fieldErrors[key] = value
+  })
+
+  if (Object.values(errors).some(Boolean)) {
+    errorMessage.value = '필수 입력값을 확인한 뒤 다시 저장하세요.'
+    return
+  }
+
+  const productLabel = productForm.value.productName || productForm.value.sku
+  // TODO(frontend): 상품 등록 API와 저장 후 후속 이동을 연결한다.
+  successMessage.value = `${productLabel} 상품 등록 준비가 완료되었습니다. 실제 저장은 다음 단계에서 연결합니다.`
+}
+</script>
+
+<template>
+  <AppLayout title="상품 등록" :breadcrumb="breadcrumb">
+    <section class="seller-product-register-page">
+      <form class="product-layout" @submit.prevent="handleSubmit">
+        <div class="product-main">
+          <!-- 기본 식별 정보와 카테고리를 먼저 입력하는 카드 -->
+          <section class="panel-card">
+            <header class="panel-header">
+              <span class="panel-accent" aria-hidden="true" />
+              <h2 class="panel-title">기본 정보</h2>
+            </header>
+
+            <div class="form-grid form-grid--2">
+              <BaseForm label="SKU" required :error="fieldErrors.sku">
+                <input v-model="productForm.sku" type="text" placeholder="예: LB-AMP-30" />
+              </BaseForm>
+
+              <BaseForm label="상품명" required :error="fieldErrors.productName">
+                <input v-model="productForm.productName" type="text" placeholder="예: 루미에르 앰플 30ml" />
+              </BaseForm>
+
+              <BaseForm label="카테고리" required :error="fieldErrors.category">
+                <select v-model="productForm.category">
+                  <option value="">선택</option>
+                  <option
+                    v-for="category in SELLER_PRODUCT_CATEGORY_OPTIONS"
+                    :key="category.value"
+                    :value="category.value"
+                  >
+                    {{ category.label }}
+                  </option>
+                </select>
+              </BaseForm>
+
+              <BaseForm label="브랜드">
+                <input v-model="productForm.brand" type="text" />
+              </BaseForm>
+
+              <BaseForm class="form-span-2" label="상품 설명">
+                <textarea
+                  v-model="productForm.description"
+                  rows="4"
+                  placeholder="상품 설명을 입력하세요."
+                />
+              </BaseForm>
+            </div>
+          </section>
+
+          <!-- 가격, 중량, 치수 입력과 자동 계산 부피중량 카드 -->
+          <section class="panel-card">
+            <header class="panel-header">
+              <span class="panel-accent" aria-hidden="true" />
+              <h2 class="panel-title">가격 · 중량 · 치수</h2>
+            </header>
+
+            <div class="form-grid form-grid--4">
+              <BaseForm label="판매가(USD)" required :error="fieldErrors.salePrice">
+                <input v-model="productForm.salePrice" type="number" min="0" step="0.01" placeholder="0.00" />
+              </BaseForm>
+
+              <BaseForm label="원가(USD)">
+                <input v-model="productForm.costPrice" type="number" min="0" step="0.01" placeholder="0.00" />
+              </BaseForm>
+
+              <BaseForm label="중량(lbs)" required :error="fieldErrors.weight">
+                <input v-model="productForm.weight" type="number" min="0" step="0.001" placeholder="0.000" />
+              </BaseForm>
+
+              <BaseForm label="부피중량(lbs)" hint="길이, 너비, 높이 기준 자동 계산">
+                <input :value="volumeWeight" type="text" placeholder="자동계산" readonly />
+              </BaseForm>
+            </div>
+
+            <div class="form-grid form-grid--3">
+              <BaseForm label="길이(L/inch)" required :error="fieldErrors.length">
+                <input v-model="productForm.length" type="number" min="0" step="0.1" placeholder="0" />
+              </BaseForm>
+
+              <BaseForm label="너비(W/inch)" required :error="fieldErrors.width">
+                <input v-model="productForm.width" type="number" min="0" step="0.1" placeholder="0" />
+              </BaseForm>
+
+              <BaseForm label="높이(H/inch)" required :error="fieldErrors.height">
+                <input v-model="productForm.height" type="number" min="0" step="0.1" placeholder="0" />
+              </BaseForm>
+            </div>
+          </section>
+
+          <!-- 통관 필드와 HS 코드 조회 자리만 먼저 구현한다. -->
+          <section class="panel-card">
+            <header class="panel-header">
+              <span class="panel-accent" aria-hidden="true" />
+              <h2 class="panel-title">통관 정보</h2>
+            </header>
+
+            <div class="form-grid form-grid--3">
+              <BaseForm label="HS 코드" hint="선택 항목">
+                <div class="field-with-action">
+                  <select v-model="productForm.hsCode">
+                    <option value="">선택 안 함</option>
+                    <option
+                      v-for="hsCode in SELLER_PRODUCT_HS_CODE_OPTIONS"
+                      :key="hsCode.value"
+                      :value="hsCode.value"
+                    >
+                      {{ hsCode.label }}
+                    </option>
+                  </select>
+
+                  <button
+                    class="ui-btn ui-btn--ghost inline-btn"
+                    type="button"
+                    @click="showHelperMessage('HS 코드 조회 UI는 다음 단계에서 연결합니다.')"
+                  >
+                    조회
+                  </button>
+                </div>
+              </BaseForm>
+
+              <BaseForm label="원산지" required :error="fieldErrors.originCountry">
+                <select v-model="productForm.originCountry">
+                  <option value="">원산지를 선택하세요</option>
+                  <option
+                    v-for="origin in SELLER_PRODUCT_ORIGIN_OPTIONS"
+                    :key="origin.value"
+                    :value="origin.value"
+                  >
+                    {{ origin.label }}
+                  </option>
+                </select>
+              </BaseForm>
+
+              <BaseForm label="신고가(USD)" required :error="fieldErrors.customsValue">
+                <input v-model="productForm.customsValue" type="number" min="0" step="0.01" placeholder="0.00" />
+              </BaseForm>
+            </div>
+          </section>
+
+          <!-- 바코드와 ASIN 은 입력만 받을 수 있게 먼저 열어 둔다. -->
+          <section class="panel-card">
+            <header class="panel-header">
+              <span class="panel-accent" aria-hidden="true" />
+              <h2 class="panel-title">바코드</h2>
+            </header>
+
+            <div class="form-grid form-grid--2">
+              <BaseForm label="EAN-13 / UPC">
+                <div class="field-with-action">
+                  <input
+                    v-model="productForm.barcode"
+                    type="text"
+                    placeholder="바코드 번호 입력 또는 스캔"
+                  />
+
+                  <button
+                    class="ui-btn ui-btn--ghost inline-btn"
+                    type="button"
+                    @click="showHelperMessage('바코드 스캔 기능은 다음 단계에서 연결합니다.')"
+                  >
+                    스캔
+                  </button>
+                </div>
+              </BaseForm>
+
+              <BaseForm label="ASIN (Amazon)">
+                <input v-model="productForm.asin" type="text" placeholder="Amazon ASIN 코드" />
+              </BaseForm>
+            </div>
+          </section>
+
+          <div class="action-row">
+            <button class="ui-btn ui-btn--ghost" type="button" @click="handleCancel">취소</button>
+            <button class="ui-btn ui-btn--ghost" type="button" @click="handleDraftSave">임시저장</button>
+            <button class="ui-btn ui-btn--primary" type="submit">상품 등록</button>
+          </div>
+
+          <p v-if="infoMessage" class="page-message page-message--info">{{ infoMessage }}</p>
+          <p v-if="successMessage" class="page-message page-message--success">{{ successMessage }}</p>
+          <p v-if="errorMessage" class="page-message page-message--error">{{ errorMessage }}</p>
+        </div>
+
+        <aside class="product-side">
+          <!-- 실제 업로드 대신 파일명과 슬롯 미리보기로 이미지 카드만 먼저 구현한다. -->
+          <section class="side-card">
+            <header class="panel-header">
+              <span class="panel-accent" aria-hidden="true" />
+              <h2 class="panel-title">상품 이미지</h2>
+            </header>
+
+            <div class="image-upload">
+              <FileUpload
+                accept=".jpg,.jpeg,.png"
+                :multiple="true"
+                @file-selected="handleImageSelected"
+              />
+            </div>
+
+            <p class="side-caption">JPG, PNG · 최대 5MB</p>
+
+            <div class="image-slots">
+              <div
+                v-for="(slot, index) in imageSlots"
+                :key="`image-slot-${index + 1}`"
+                class="image-slot"
+                :class="{ 'image-slot--filled': slot }"
+              >
+                <span v-if="slot" class="image-slot-name">{{ slot.name }}</span>
+                <span v-else class="image-slot-plus">+</span>
+              </div>
+            </div>
+          </section>
+
+          <!-- 판매 설정은 토글형 UI만 먼저 제공한다. -->
+          <section class="side-card">
+            <header class="panel-header">
+              <span class="panel-accent" aria-hidden="true" />
+              <h2 class="panel-title">판매 설정</h2>
+            </header>
+
+            <div class="setting-list">
+              <div class="setting-row">
+                <div>
+                  <p class="setting-title">판매 활성화</p>
+                  <p class="setting-description">비활성 시 주문 불가</p>
+                </div>
+
+                <button
+                  class="toggle-switch"
+                  :class="{ 'toggle-switch--on': productForm.isActive }"
+                  type="button"
+                  :aria-pressed="productForm.isActive"
+                  @click="handleToggle('isActive')"
+                >
+                  <span class="toggle-switch-thumb" />
+                </button>
+              </div>
+
+              <div class="setting-row">
+                <div>
+                  <p class="setting-title">재고 부족 경고</p>
+                  <p class="setting-description">임계치 이하 시 알림</p>
+                </div>
+
+                <button
+                  class="toggle-switch"
+                  :class="{ 'toggle-switch--on': productForm.lowStockAlert }"
+                  type="button"
+                  :aria-pressed="productForm.lowStockAlert"
+                  @click="handleToggle('lowStockAlert')"
+                >
+                  <span class="toggle-switch-thumb" />
+                </button>
+              </div>
+
+              <div class="setting-row setting-row--last">
+                <div>
+                  <p class="setting-title">Amazon 채널 연동</p>
+                  <p class="setting-description">ASIN 연동 시 자동 수집</p>
+                </div>
+
+                <button
+                  class="toggle-switch"
+                  :class="{ 'toggle-switch--on': productForm.amazonSync }"
+                  type="button"
+                  :aria-pressed="productForm.amazonSync"
+                  @click="handleToggle('amazonSync')"
+                >
+                  <span class="toggle-switch-thumb" />
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <!-- 재고 설정은 숫자 입력만 먼저 열어 둔다. -->
+          <section class="side-card">
+            <header class="panel-header">
+              <span class="panel-accent" aria-hidden="true" />
+              <h2 class="panel-title">재고 설정</h2>
+            </header>
+
+            <div class="side-form-stack">
+              <BaseForm label="재고 경고 임계치">
+                <div class="unit-input">
+                  <input v-model="productForm.stockAlertThreshold" type="number" min="0" step="1" />
+                  <span class="unit-label">개</span>
+                </div>
+              </BaseForm>
+
+              <BaseForm label="최소 주문 수량">
+                <div class="unit-input">
+                  <input v-model="productForm.minOrderQuantity" type="number" min="1" step="1" />
+                  <span class="unit-label">개</span>
+                </div>
+              </BaseForm>
+            </div>
+          </section>
+        </aside>
+      </form>
+    </section>
+  </AppLayout>
+</template>
+
+<style scoped>
+.seller-product-register-page {
+  display: flex;
+  flex-direction: column;
+}
+
+.product-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: var(--space-5);
+  align-items: start;
+}
+
+.product-main,
+.product-side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.panel-card,
+.side-card {
+  padding: var(--space-5) var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.panel-accent {
+  width: 3px;
+  height: 14px;
+  border-radius: var(--radius-full);
+  background: var(--gold);
+}
+
+.panel-title {
+  color: var(--t1);
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.form-grid {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.form-grid--2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.form-grid--3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: var(--space-3);
+}
+
+.form-grid--4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.form-span-2 {
+  grid-column: span 2;
+}
+
+.field-with-action {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.inline-btn {
+  white-space: nowrap;
+}
+
+.action-row {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+}
+
+.page-message {
+  margin-top: calc(var(--space-2) * -1);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.page-message--info {
+  color: var(--t3);
+}
+
+.page-message--success {
+  color: var(--green);
+}
+
+.page-message--error {
+  color: var(--red);
+}
+
+.image-upload :deep(.upload-zone) {
+  min-height: 132px;
+  padding: var(--space-5);
+}
+
+.side-caption {
+  margin-top: var(--space-2);
+  color: var(--t4);
+  font-size: var(--font-size-xs);
+}
+
+.image-slots {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.image-slot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  padding: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  text-align: center;
+}
+
+.image-slot--filled {
+  background: var(--gold-pale);
+  border-color: var(--gold);
+}
+
+.image-slot-name {
+  color: var(--t2);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.image-slot-plus {
+  color: var(--t4);
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+}
+
+.setting-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.setting-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.setting-row--last {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.setting-title {
+  color: var(--t2);
+  font-size: var(--font-size-md);
+}
+
+.setting-description {
+  margin-top: var(--space-1);
+  color: var(--t4);
+  font-size: var(--font-size-xs);
+}
+
+.toggle-switch {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--border);
+  cursor: pointer;
+  transition: background var(--ease-fast);
+}
+
+.toggle-switch--on {
+  background: var(--gold);
+}
+
+.toggle-switch-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--ease-fast);
+}
+
+.toggle-switch--on .toggle-switch-thumb {
+  transform: translateX(18px);
+}
+
+.side-form-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.unit-input {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.unit-label {
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+@media (max-width: 1280px) {
+  .product-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .product-side {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-4);
+  }
+}
+
+@media (max-width: 1024px) {
+  .form-grid--4,
+  .form-grid--3,
+  .form-grid--2,
+  .product-side {
+    grid-template-columns: 1fr;
+  }
+
+  .form-span-2 {
+    grid-column: span 1;
+  }
+}
+</style>

--- a/src/views/seller/__tests__/productRegister.utils.test.js
+++ b/src/views/seller/__tests__/productRegister.utils.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildVolumeWeight,
+  createInitialProductForm,
+  validateProductForm,
+} from '@/utils/productRegister.utils.js'
+
+describe('productRegister utils', () => {
+  it('길이, 너비, 높이로 부피중량을 계산한다', () => {
+    expect(buildVolumeWeight(12, 8, 6)).toBe(4.144)
+  })
+
+  it('필수값이 비어 있으면 상품 등록 검증 에러를 반환한다', () => {
+    const result = validateProductForm(createInitialProductForm())
+
+    expect(result.sku).toBe('SKU를 입력하세요.')
+    expect(result.productName).toBe('상품명을 입력하세요.')
+    expect(result.category).toBe('카테고리를 선택하세요.')
+    expect(result.salePrice).toBe('판매가는 0보다 커야 합니다.')
+    expect(result.weight).toBe('중량을 입력하세요.')
+    expect(result.length).toBe('길이를 입력하세요.')
+    expect(result.width).toBe('너비를 입력하세요.')
+    expect(result.height).toBe('높이를 입력하세요.')
+    expect(result.originCountry).toBe('원산지를 선택하세요.')
+    expect(result.customsValue).toBe('신고가를 입력하세요.')
+  })
+
+  it('정상 입력이면 상품 등록 검증 에러가 없다', () => {
+    const result = validateProductForm({
+      sku: 'LB-AMP-30',
+      productName: '루미에르 앰플 30ml',
+      category: 'SERUM',
+      salePrice: 24.99,
+      weight: 0.32,
+      length: 6,
+      width: 2,
+      height: 2,
+      originCountry: 'KR',
+      customsValue: 12.5,
+    })
+
+    expect(Object.values(result).every((value) => value === '')).toBe(true)
+  })
+})


### PR DESCRIPTION
  ## 💡 관련 이슈
  - close #이슈번호

  ## 📝 변경 사항
  - Seller 상품 등록 화면을 UI + 로컬 mock 데이터 기준으로 구현했습니다.
  - 기본 정보, 가격·중량·치수, 통관 정보, 바코드, 상품 이미지, 판매 설정, 재고 설정까지 화면 구성을 완료했습니다.
  - 상품 등록 라우트와 메뉴를 추가하고, 상품 등록 전용 유틸과 테스트를 함께 작성했습니다.

## 💡 관련 이슈
close #55 

## 🔍 주요 작업 내용
  - [x] Backend: 없음
  - [x] Frontend: `SELLER_PRODUCT_REGISTER` 라우트 추가
  - [x] Frontend: Seller 메뉴에 상품 등록 추가
  - [x] Frontend: 상품 등록 화면 생성
  - [x] Frontend: 기본 정보 섹션 UI 구현
  - [x] Frontend: 가격 · 중량 · 치수 섹션 UI 구현
  - [x] Frontend: 통관 정보 섹션 UI 구현
  - [x] Frontend: 바코드 섹션 UI 구현
  - [x] Frontend: 상품 이미지 업로드 UI 및 최대 3장 슬롯 미리보기 구현
  - [x] Frontend: 판매 설정 토글 UI 구현
  - [x] Frontend: 재고 설정 UI 구현
  - [x] Frontend: 부피중량 자동 계산 로직 추가
  - [x] Frontend: 상품 등록 로컬 검증 유틸 및 테스트 추가
  - [x] Frontend: Seller 문서 최신화
  - [ ] DB: 없음

  ## 📸 스크린샷 (선택)
  - Seller 상품 등록 화면
 
<img width="2560" height="1309" alt="스크린샷 2026-03-18 오후 10 42 01" src="https://github.com/user-attachments/assets/f95f1ed2-160f-4f00-a072-db32395f8d66" />


  - 부피중량 자동 계산 화면
<img width="1919" height="234" alt="스크린샷 2026-03-18 오후 10 43 35" src="https://github.com/user-attachments/assets/d2e38656-936b-4b07-9650-0a2c1022f8b6" />


  - 이미지 슬롯 미리보기 화면
<img width="307" height="343" alt="스크린샷 2026-03-18 오후 10 42 10" src="https://github.com/user-attachments/assets/0628f29f-81c9-4fde-abe3-29dd7c31e117" />


  - 상품 등록 검증 메시지 화면
<img width="2560" height="1316" alt="스크린샷 2026-03-18 오후 10 38 45" src="https://github.com/user-attachments/assets/9187717a-143c-4cd9-ba16-8a10f786c5e4" />



  ## 💬 리뷰어에게 한마디
  - 이번 PR은 UI 중심 작업이라 실제 상품 저장 API, 이미지 업로드 저장, HS 코드 조회, 바코드 스캔은 아직 연결하지 않았습니다.
  - `임시저장`, `상품 등록` 버튼은 현재 단계에서 로컬 메시지로만 동작합니다.
  - Pigma `seller-product-register.html` 구조를 기준으로 맞췄고, 다음 단계는 `상품 목록` 화면 UI 구현입니다.
