### PR TITLE
셀러 재고 목록 UI 구현

### DIFF
--- a/src/utils/inventoryList.utils.js
+++ b/src/utils/inventoryList.utils.js
@@ -1,0 +1,208 @@
+/**
+ * 셀러 재고 목록 화면용 로컬 mock 데이터와 가공 유틸.
+ * API 연동 전 단계라 상태/창고 필터와 검색 흐름을 화면에서 먼저 확인할 수 있게 한다.
+ */
+
+// 재고 목록 화면에서 사용하는 상태 필터 값.
+export const SELLER_INVENTORY_STATUS_OPTIONS = [
+  { key: 'all', label: '전체' },
+  { key: 'NORMAL', label: '정상' },
+  { key: 'LOW', label: '부족' },
+  { key: 'OUT', label: '품절' },
+]
+
+// 재고 목록 화면에서 사용하는 창고 필터 값.
+export const SELLER_INVENTORY_WAREHOUSE_OPTIONS = [
+  { key: 'all', label: '전체' },
+  { key: 'ICN-A', label: 'ICN-A' },
+  { key: 'PUS-B', label: 'PUS-B' },
+]
+
+// 재고 상태별 배지 표현을 화면 범위에서만 관리한다.
+export const SELLER_INVENTORY_STATUS_META = {
+  NORMAL: { label: '정상', tone: 'green' },
+  LOW: { label: '재고부족', tone: 'amber' },
+  OUT: { label: '품절', tone: 'red' },
+}
+
+// 재고 목록 테이블 mock 원본 데이터.
+export const SELLER_INVENTORY_LIST_ROWS = [
+  {
+    id: 'seller-inventory-1',
+    sku: 'LB-AMP-30',
+    productName: '루미에르 앰플 30ml',
+    warehouseName: 'ICN-A',
+    availableStock: 248,
+    allocatedStock: 32,
+    totalStock: 280,
+    inboundExpected: 50,
+    lastInboundDate: '2026-03-08',
+    warningThreshold: 10,
+    status: 'NORMAL',
+  },
+  {
+    id: 'seller-inventory-2',
+    sku: 'LB-SRM-50',
+    productName: '히알루론 세럼 50ml',
+    warehouseName: 'ICN-A',
+    availableStock: 8,
+    allocatedStock: 12,
+    totalStock: 20,
+    inboundExpected: 100,
+    lastInboundDate: '2026-02-28',
+    warningThreshold: 20,
+    status: 'LOW',
+  },
+  {
+    id: 'seller-inventory-3',
+    sku: 'LB-CRM-100',
+    productName: '비타민C 크림 100ml',
+    warehouseName: 'PUS-B',
+    availableStock: 152,
+    allocatedStock: 18,
+    totalStock: 170,
+    inboundExpected: 0,
+    lastInboundDate: '2026-03-05',
+    warningThreshold: 15,
+    status: 'NORMAL',
+  },
+  {
+    id: 'seller-inventory-4',
+    sku: 'LB-MSK-5P',
+    productName: '콜라겐 마스크 5매입',
+    warehouseName: 'ICN-A',
+    availableStock: 420,
+    allocatedStock: 60,
+    totalStock: 480,
+    inboundExpected: 200,
+    lastInboundDate: '2026-03-10',
+    warningThreshold: 30,
+    status: 'NORMAL',
+  },
+  {
+    id: 'seller-inventory-5',
+    sku: 'LB-TNR-150',
+    productName: '리파이닝 토너 150ml',
+    warehouseName: 'PUS-B',
+    availableStock: 0,
+    allocatedStock: 0,
+    totalStock: 0,
+    inboundExpected: 150,
+    lastInboundDate: '2026-02-20',
+    warningThreshold: 20,
+    status: 'OUT',
+  },
+  {
+    id: 'seller-inventory-6',
+    sku: 'LB-EYE-20',
+    productName: '아이크림 20ml',
+    warehouseName: 'ICN-A',
+    availableStock: 67,
+    allocatedStock: 8,
+    totalStock: 75,
+    inboundExpected: 0,
+    lastInboundDate: '2026-03-02',
+    warningThreshold: 10,
+    status: 'NORMAL',
+  },
+  {
+    id: 'seller-inventory-7',
+    sku: 'LB-CLN-200',
+    productName: '젤 클렌저 200ml',
+    warehouseName: 'ICN-A',
+    availableStock: 310,
+    allocatedStock: 40,
+    totalStock: 350,
+    inboundExpected: 0,
+    lastInboundDate: '2026-03-06',
+    warningThreshold: 25,
+    status: 'NORMAL',
+  },
+  {
+    id: 'seller-inventory-8',
+    sku: 'LB-SUN-50',
+    productName: 'UV 선크림 SPF50 50ml',
+    warehouseName: 'PUS-B',
+    availableStock: 5,
+    allocatedStock: 3,
+    totalStock: 8,
+    inboundExpected: 80,
+    lastInboundDate: '2026-02-25',
+    warningThreshold: 15,
+    status: 'LOW',
+  },
+  {
+    id: 'seller-inventory-9',
+    sku: 'LB-MST-100',
+    productName: '미스트 토닝 100ml',
+    warehouseName: 'ICN-A',
+    availableStock: 185,
+    allocatedStock: 20,
+    totalStock: 205,
+    inboundExpected: 0,
+    lastInboundDate: '2026-03-08',
+    warningThreshold: 20,
+    status: 'NORMAL',
+  },
+  {
+    id: 'seller-inventory-10',
+    sku: 'LB-EXF-80',
+    productName: '엑스폴리에이팅 스크럽 80g',
+    warehouseName: 'PUS-B',
+    availableStock: 93,
+    allocatedStock: 7,
+    totalStock: 100,
+    inboundExpected: 50,
+    lastInboundDate: '2026-03-01',
+    warningThreshold: 18,
+    status: 'NORMAL',
+  },
+]
+
+// 재고 목록 테이블 렌더링에 사용하는 컬럼 정의.
+export const SELLER_INVENTORY_LIST_COLUMNS = [
+  { key: 'sku', label: 'SKU', width: '130px' },
+  { key: 'productName', label: '상품명', width: '220px' },
+  { key: 'warehouseName', label: '창고', width: '110px' },
+  { key: 'availableStock', label: '가용재고', width: '110px', align: 'right' },
+  { key: 'allocatedStock', label: '할당재고', width: '110px', align: 'right' },
+  { key: 'totalStock', label: '총재고', width: '110px', align: 'right' },
+  { key: 'inboundExpected', label: '입고예정', width: '110px', align: 'right' },
+  { key: 'lastInboundDate', label: '최근 입고일', width: '130px' },
+  { key: 'warningThreshold', label: '경고 임계치', width: '120px', align: 'right' },
+  { key: 'status', label: '상태', width: '120px' },
+]
+
+// 재고 상태 라벨과 배지 색상을 반환한다.
+export function getSellerInventoryStatusMeta(status) {
+  return SELLER_INVENTORY_STATUS_META[status] ?? { label: status ?? '-', tone: 'default' }
+}
+
+/**
+ * 상태, 창고, 검색어를 함께 적용해 재고 목록을 만든다.
+ * 검색은 SKU, 상품명, 창고명을 함께 조회한다.
+ */
+export function filterSellerInventoryRows(
+  rows = [],
+  { status = 'all', warehouse = 'all', search = '' } = {},
+) {
+  const normalizedSearch = String(search).trim().toLowerCase()
+
+  return rows.filter((row) => {
+    const matchesStatus = status === 'all' || row.status === status
+    const matchesWarehouse = warehouse === 'all' || row.warehouseName === warehouse
+
+    if (!normalizedSearch) return matchesStatus && matchesWarehouse
+
+    const haystack = [
+      row.sku,
+      row.productName,
+      row.warehouseName,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+
+    return matchesStatus && matchesWarehouse && haystack.includes(normalizedSearch)
+  })
+}

--- a/src/views/seller/SellerInventoryListView.vue
+++ b/src/views/seller/SellerInventoryListView.vue
@@ -1,0 +1,374 @@
+<script setup>
+/**
+ * 셀러 재고 목록 화면.
+ * Pigma 재고 목록 시안을 기준으로 상태/창고 필터와 테이블 UI를 로컬 mock 데이터로 먼저 구성한다.
+ */
+import { computed, ref, watch } from 'vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import BaseTable from '@/components/common/BaseTable.vue'
+import {
+  filterSellerInventoryRows,
+  getSellerInventoryStatusMeta,
+  SELLER_INVENTORY_LIST_COLUMNS,
+  SELLER_INVENTORY_LIST_ROWS,
+  SELLER_INVENTORY_STATUS_OPTIONS,
+  SELLER_INVENTORY_WAREHOUSE_OPTIONS,
+} from '@/utils/inventoryList.utils.js'
+
+const breadcrumb = [{ label: 'Seller' }, { label: '재고 목록' }]
+
+// 목록 화면은 상태, 창고, 검색어 조합으로 먼저 필터링한다.
+const activeStatus = ref('all')
+const activeWarehouse = ref('all')
+const searchKeyword = ref('')
+const toolbarMessage = ref('')
+
+// 페이지네이션은 로컬 mock 기준으로 단순 처리한다.
+const currentPage = ref(1)
+const PAGE_SIZE = 10
+
+// 필터가 바뀌면 첫 페이지로 되돌린다.
+watch([activeStatus, activeWarehouse, searchKeyword], () => {
+  currentPage.value = 1
+})
+
+// 현재 상태와 창고, 검색어를 기준으로 재고 목록을 필터링한다.
+const filteredRows = computed(() => {
+  return filterSellerInventoryRows(SELLER_INVENTORY_LIST_ROWS, {
+    status: activeStatus.value,
+    warehouse: activeWarehouse.value,
+    search: searchKeyword.value,
+  })
+})
+
+// 현재 페이지에 해당하는 구간만 잘라서 테이블에 전달한다.
+const pagedRows = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filteredRows.value.slice(start, start + PAGE_SIZE)
+})
+
+const pagination = computed(() => ({
+  page: currentPage.value,
+  pageSize: PAGE_SIZE,
+  total: filteredRows.value.length,
+}))
+
+function handlePageChange(page) {
+  currentPage.value = page
+}
+
+// UI 범위만 구현하므로 CSV와 상세 모달은 안내 메시지로 처리한다.
+function showToolbarMessage(message) {
+  toolbarMessage.value = message
+}
+</script>
+
+<template>
+  <AppLayout title="재고 목록" :breadcrumb="breadcrumb">
+    <section class="seller-inventory-list-page">
+      <section class="list-card">
+        <div class="toolbar">
+          <div class="filter-stack">
+            <div class="filter-row">
+              <span class="filter-label">상태</span>
+
+              <button
+                v-for="option in SELLER_INVENTORY_STATUS_OPTIONS"
+                :key="option.key"
+                type="button"
+                class="filter-badge"
+                :class="{ 'filter-badge--active': activeStatus === option.key }"
+                @click="activeStatus = option.key"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+
+            <div class="filter-row">
+              <span class="filter-label">창고</span>
+
+              <button
+                v-for="option in SELLER_INVENTORY_WAREHOUSE_OPTIONS"
+                :key="option.key"
+                type="button"
+                class="filter-badge"
+                :class="{ 'filter-badge--active': activeWarehouse === option.key }"
+                @click="activeWarehouse = option.key"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+          </div>
+
+          <div class="toolbar-right">
+            <label class="search-box">
+              <input
+                v-model="searchKeyword"
+                type="text"
+                placeholder="SKU 또는 상품명 검색"
+              />
+            </label>
+
+            <!-- TODO(frontend): 재고 목록 CSV 내보내기 기능을 연결한다. -->
+            <button
+              class="ui-btn ui-btn--ghost toolbar-btn"
+              type="button"
+              @click="showToolbarMessage('CSV 내보내기 UI는 다음 단계에서 연결합니다.')"
+            >
+              CSV 내보내기
+            </button>
+          </div>
+        </div>
+
+        <p v-if="toolbarMessage" class="toolbar-message">{{ toolbarMessage }}</p>
+
+        <BaseTable
+          :columns="SELLER_INVENTORY_LIST_COLUMNS"
+          :rows="pagedRows"
+          :pagination="pagination"
+          row-key="id"
+          @page-change="handlePageChange"
+        >
+          <template #cell-sku="{ value }">
+            <span class="sku-code">{{ value }}</span>
+          </template>
+
+          <template #cell-warehouseName="{ value }">
+            <span class="warehouse-chip">{{ value }}</span>
+          </template>
+
+          <template #cell-availableStock="{ value, row }">
+            <span
+              class="stock-value"
+              :class="{
+                'stock-value--low': row.status === 'LOW',
+                'stock-value--empty': row.status === 'OUT',
+              }"
+            >
+              {{ value.toLocaleString() }}
+            </span>
+          </template>
+
+          <template #cell-allocatedStock="{ value }">
+            <span class="stock-sub-value">{{ value.toLocaleString() }}</span>
+          </template>
+
+          <template #cell-totalStock="{ value }">
+            <span class="stock-total">{{ value.toLocaleString() }}</span>
+          </template>
+
+          <template #cell-inboundExpected="{ value }">
+            <span class="stock-sub-value">{{ value.toLocaleString() }}</span>
+          </template>
+
+          <template #cell-warningThreshold="{ value }">
+            <span class="stock-sub-value">{{ value.toLocaleString() }}</span>
+          </template>
+
+          <template #cell-status="{ value }">
+            <!-- TODO(frontend): 재고 상세 모달 또는 상세 화면을 연결한다. -->
+            <span
+              class="inventory-status-badge"
+              :class="`inventory-status-badge--${getSellerInventoryStatusMeta(value).tone}`"
+            >
+              {{ getSellerInventoryStatusMeta(value).label }}
+            </span>
+          </template>
+        </BaseTable>
+      </section>
+    </section>
+  </AppLayout>
+</template>
+
+<style scoped>
+.seller-inventory-list-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.list-card {
+  padding: var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+}
+
+.filter-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.filter-label {
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.filter-badge {
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--surface);
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--ease-fast),
+    border-color var(--ease-fast),
+    color var(--ease-fast);
+}
+
+.filter-badge--active {
+  border-color: var(--gold);
+  background: var(--gold-pale);
+  color: var(--t1);
+}
+
+.toolbar-right {
+  display: flex;
+  flex: 1 1 auto;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.search-box {
+  display: flex;
+  flex: 1 1 240px;
+  min-width: 220px;
+  max-width: 280px;
+}
+
+.search-box input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--t2);
+  font-size: var(--font-size-sm);
+  outline: none;
+  transition:
+    border-color var(--ease-fast),
+    box-shadow var(--ease-fast);
+}
+
+.search-box input:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--blue-pale);
+}
+
+.search-box input::placeholder {
+  color: var(--t4);
+}
+
+.toolbar-btn {
+  min-width: 112px;
+  padding-inline: 16px;
+  flex-shrink: 0;
+}
+
+.toolbar-message {
+  margin-bottom: var(--space-3);
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.sku-code {
+  color: var(--t1);
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-md);
+  font-weight: 700;
+}
+
+.warehouse-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--t2);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+}
+
+.stock-value {
+  color: var(--t1);
+  font-weight: 700;
+}
+
+.stock-value--low {
+  color: var(--amber);
+}
+
+.stock-value--empty {
+  color: var(--red);
+}
+
+.stock-sub-value {
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+}
+
+.stock-total {
+  color: var(--t1);
+  font-weight: 600;
+}
+
+.inventory-status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.inventory-status-badge--green {
+  background: var(--green-pale);
+  color: var(--green);
+}
+
+.inventory-status-badge--amber {
+  background: var(--gold-pale);
+  color: #92400e;
+}
+
+.inventory-status-badge--red {
+  background: var(--red-pale);
+  color: #7f1d1d;
+}
+
+@media (max-width: 1200px) {
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar-right {
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/src/views/seller/__tests__/inventoryList.utils.test.js
+++ b/src/views/seller/__tests__/inventoryList.utils.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  filterSellerInventoryRows,
+  getSellerInventoryStatusMeta,
+  SELLER_INVENTORY_LIST_ROWS,
+} from '@/utils/inventoryList.utils.js'
+
+describe('inventoryList utils', () => {
+  it('재고 상태 메타를 반환한다', () => {
+    expect(getSellerInventoryStatusMeta('LOW')).toEqual({
+      label: '재고부족',
+      tone: 'amber',
+    })
+  })
+
+  it('상태 필터를 적용한다', () => {
+    const result = filterSellerInventoryRows(SELLER_INVENTORY_LIST_ROWS, {
+      status: 'OUT',
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].sku).toBe('LB-TNR-150')
+  })
+
+  it('창고와 검색어를 함께 적용한다', () => {
+    const result = filterSellerInventoryRows(SELLER_INVENTORY_LIST_ROWS, {
+      warehouse: 'PUS-B',
+      search: '선크림',
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].sku).toBe('LB-SUN-50')
+  })
+})


### PR DESCRIPTION
  ## 💡 관련 이슈
  - close #57

  ## 📝 변경 사항
  - Seller 재고 목록 화면을 UI + 로컬 mock 데이터 기준으로 구현했습니다.
  - 상태 필터, 창고 필터, 검색, 테이블, 페이지네이션을 연결했습니다.
  - Seller 메뉴와 라우트에 재고 목록을 추가하고, 재고 목록 전용 유틸과 테스트를 함께 작성했습니다.

  ## 🔍 주요 작업 내용
  - [x] Backend: 없음
  - [x] Frontend: `SELLER_INVENTORY` 라우트 추가
  - [x] Frontend: Seller 메뉴에 재고 목록 추가
  - [x] Frontend: 재고 목록 화면 생성
  - [x] Frontend: 상태 필터 UI 구현
  - [x] Frontend: 창고 필터 UI 구현
  - [x] Frontend: 검색 입력 UI 구현
  - [x] Frontend: 재고 목록 테이블 및 페이지네이션 구현
  - [x] Frontend: 창고 칩 / 상태 배지 / 재고 수치 UI 구현
  - [x] Frontend: 재고 목록 mock 데이터 및 필터 유틸 추가
  - [x] Frontend: 재고 목록 유틸 테스트 추가
  - [x] Frontend: Seller 개발로그 최신화
  - [x] DB: 없음

  ## 📸 스크린샷 (선택)
  - Seller 재고 목록 화면
<img width="1470" height="956" alt="스크린샷 2026-03-18 오후 11 43 51" src="https://github.com/user-attachments/assets/ae438108-a229-4906-b85e-caed0594d59a" />


  - 상태 필터 적용 화면
<img width="1470" height="956" alt="스크린샷 2026-03-18 오후 11 43 57" src="https://github.com/user-attachments/assets/1ba28537-73b4-4ef0-9560-a27879e7164f" />


  - 창고 필터 적용 화면
<img width="1470" height="956" alt="스크린샷 2026-03-18 오후 11 44 00" src="https://github.com/user-attachments/assets/a1eeccb9-22c8-41df-a8e5-ecf5a2c6f37b" />


  - 검색 결과 화면
<img width="1470" height="956" alt="스크린샷 2026-03-18 오후 11 44 13" src="https://github.com/user-attachments/assets/8cb2b445-73e5-4690-9d3e-8a114c452af5" />

  ## 💬 리뷰어에게 한마디
  - 이번 PR은 UI 중심 작업이라 실제 재고 조회 API, CSV 다운로드, 재고 상세 모달은 아직 연결하지 않았습니다.
  - `CSV 내보내기`는 현재 단계에서 안내 메시지만 표시합니다.
  - figma `seller-inventory-list.html` 구조를 기준으로 맞췄고, 다음 단계는 `주문 연동 및 조회` 또는 `마진 시뮬레이터` 화면 UI 구현입니다.