### PR TITLE
셀러 주문 연동, 마진, 알림 UI 추가

### DIFF
--- a/src/components/layout/menus/seller.js
+++ b/src/components/layout/menus/seller.js
@@ -10,7 +10,8 @@
  *   SELLER_DASHBOARD, SELLER_PRODUCT_LIST, SELLER_PRODUCT_REGISTER,
  *   SELLER_ASN_LIST, SELLER_ASN_CREATE, SELLER_ASN_DETAIL,
  *   SELLER_INVENTORY, SELLER_ORDER_LIST, SELLER_ORDER_DETAIL,
- *   SELLER_ORDER_REGISTER, SELLER_AMAZON_CONNECT, SELLER_MARGIN_SIMULATOR
+ *   SELLER_ORDER_REGISTER, SELLER_AMAZON_CONNECT, SELLER_MARGIN_SIMULATOR,
+ *   SELLER_NOTIFICATIONS
  */
 import { ROUTE_NAMES } from '@/constants'
 
@@ -38,8 +39,19 @@ export const SELLER_MENU_GROUPS = [
     label: '조회',
     items: [
       { name: ROUTE_NAMES.SELLER_ORDER_LIST, label: '주문 목록', icon: '≣' },
+      { name: ROUTE_NAMES.SELLER_PRODUCT_LIST, label: '상품 목록', icon: '▤' },
       { name: ROUTE_NAMES.SELLER_INVENTORY, label: '재고 목록', icon: '▥' },
       { name: ROUTE_NAMES.SELLER_ASN_LIST, label: 'ASN 목록', icon: '⋯' },
+    ],
+  },
+
+  // Seller 부가 기능 메뉴
+  {
+    label: '도구',
+    items: [
+      { name: ROUTE_NAMES.SELLER_AMAZON_CONNECT, label: '주문 연동 및 조회', icon: '⇄' },
+      { name: ROUTE_NAMES.SELLER_MARGIN_SIMULATOR, label: '마진 시뮬레이터', icon: '◔' },
+      { name: ROUTE_NAMES.SELLER_NOTIFICATIONS, label: '알림', icon: '•' },
     ],
   },
 ]

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -38,6 +38,7 @@ export const ROUTE_NAMES = {
   SELLER_ORDER_REGISTER: 'seller-order-register',
   SELLER_AMAZON_CONNECT: 'seller-amazon-connect',
   SELLER_MARGIN_SIMULATOR: 'seller-margin-simulator',
+  SELLER_NOTIFICATIONS: 'seller-notifications',
 
   // ── Master Admin — 창고사 관리 (views/masterAdmin/)
   MASTER_DASHBOARD: 'master-dashboard',

--- a/src/router/routes/seller.js
+++ b/src/router/routes/seller.js
@@ -73,6 +73,22 @@ export default [
   // TODO(frontend): ASN 상세 라우트 추가
 
   // 부가 기능
-  // TODO(frontend): 마진 시뮬레이터 라우트 추가
-  // TODO(frontend): 주문 연동 및 조회 라우트 추가
+  {
+    path: '/seller/channels/orders',
+    name: ROUTE_NAMES.SELLER_AMAZON_CONNECT,
+    component: () => import('@/views/seller/SellerChannelOrdersView.vue'),
+    meta: { role: ROLES.SELLER },
+  },
+  {
+    path: '/seller/margin-simulator',
+    name: ROUTE_NAMES.SELLER_MARGIN_SIMULATOR,
+    component: () => import('@/views/seller/SellerMarginSimulatorView.vue'),
+    meta: { role: ROLES.SELLER },
+  },
+  {
+    path: '/seller/notifications',
+    name: ROUTE_NAMES.SELLER_NOTIFICATIONS,
+    component: () => import('@/views/seller/SellerNotificationsView.vue'),
+    meta: { role: ROLES.SELLER },
+  },
 ]

--- a/src/utils/channelOrders.utils.js
+++ b/src/utils/channelOrders.utils.js
@@ -1,0 +1,204 @@
+/**
+ * 셀러 주문 연동 및 조회 화면용 로컬 mock 데이터와 가공 유틸.
+ * 채널 연결 상태와 통합 주문 목록, 채널 필터 흐름을 API 없이 먼저 검증한다.
+ */
+
+// 채널 연결 카드에서 사용하는 연결 상태 메타 정보.
+export const SELLER_CHANNEL_SYNC_STATUS_META = {
+  CONNECTED: { label: '연결됨', tone: 'green' },
+  PLANNED: { label: 'Phase 2 예정', tone: 'gold' },
+  DISCONNECTED: { label: '미연결', tone: 'red' },
+}
+
+// 통합 주문 목록에서 사용하는 채널 배지 메타 정보.
+export const SELLER_CHANNEL_META = {
+  AMAZON: { label: 'Amazon', tone: 'gold' },
+  SHOPIFY: { label: 'Shopify', tone: 'blue' },
+  MANUAL: { label: '수동', tone: 'default' },
+  QOO10: { label: 'Qoo10', tone: 'red' },
+}
+
+// 통합 주문 목록에서 사용하는 주문 처리 상태 메타 정보.
+export const SELLER_CHANNEL_ORDER_STATUS_META = {
+  NEW: { label: '신규', tone: 'blue' },
+  READY: { label: '출고준비', tone: 'amber' },
+  SHIPPED: { label: '출고완료', tone: 'green' },
+  DELIVERED: { label: '배송완료', tone: 'purple' },
+}
+
+// 채널 연결 현황 카드 mock 데이터.
+export const SELLER_CHANNEL_SYNC_CARDS = [
+  {
+    key: 'AMAZON',
+    label: 'Amazon',
+    syncStatus: 'PLANNED',
+    pendingOrders: 14,
+    todayImported: 3,
+    lastSyncedAt: '2026-03-19 09:10',
+    description: 'Amazon 주문을 CONK 주문번호로 매핑해 출고 상태를 추적합니다.',
+    actions: [
+      { key: 'sync', label: '동기화', variant: 'ghost', disabled: false },
+      { key: 'import', label: '주문 가져오기', variant: 'primary', disabled: false },
+    ],
+  },
+  {
+    key: 'SHOPIFY',
+    label: 'Shopify',
+    syncStatus: 'CONNECTED',
+    pendingOrders: 5,
+    todayImported: 2,
+    lastSyncedAt: '2026-03-19 08:42',
+    description: 'Shopify 주문을 자동 수집해 WMS 처리 상태와 함께 조회합니다.',
+    actions: [
+      { key: 'sync', label: '동기화', variant: 'ghost', disabled: false },
+      { key: 'import', label: '주문 가져오기', variant: 'primary', disabled: false },
+    ],
+  },
+  {
+    key: 'QOO10',
+    label: 'Qoo10',
+    syncStatus: 'DISCONNECTED',
+    pendingOrders: 0,
+    todayImported: 0,
+    lastSyncedAt: '연결 전',
+    description: '향후 연결 예정 채널입니다. 연결 전에는 주문을 직접 업로드해야 합니다.',
+    actions: [
+      { key: 'connect', label: '+ 채널 연결', variant: 'primary', disabled: false },
+    ],
+  },
+]
+
+// 채널 통합 주문 조회 상단 필터 값.
+export const SELLER_CHANNEL_FILTER_OPTIONS = [
+  { key: 'all', label: '전체' },
+  { key: 'AMAZON', label: 'Amazon' },
+  { key: 'SHOPIFY', label: 'Shopify 예정' },
+  { key: 'MANUAL', label: '수동' },
+]
+
+// 채널 통합 주문 조회 테이블 mock 원본 데이터.
+export const SELLER_CHANNEL_ORDER_ROWS = [
+  {
+    id: 'channel-order-1',
+    channel: 'AMAZON',
+    channelOrderNo: 'AMZ-4583201',
+    conkOrderNo: 'ORD-20260319-001',
+    recipient: 'Emily Harris',
+    itemsSummary: '루미에르 앰플 30ml 외 1건',
+    orderAmount: 64.5,
+    orderedAt: '2026-03-19 09:12',
+    status: 'NEW',
+  },
+  {
+    id: 'channel-order-2',
+    channel: 'MANUAL',
+    channelOrderNo: 'MANUAL-240319-01',
+    conkOrderNo: 'ORD-20260319-004',
+    recipient: '김도윤',
+    itemsSummary: '콜라겐 마스크 5매입',
+    orderAmount: 18,
+    orderedAt: '2026-03-19 08:20',
+    status: 'READY',
+  },
+  {
+    id: 'channel-order-3',
+    channel: 'SHOPIFY',
+    channelOrderNo: 'SHOP-890231',
+    conkOrderNo: 'ORD-20260318-021',
+    recipient: 'Olivia Carter',
+    itemsSummary: '리파이닝 토너 150ml',
+    orderAmount: 22,
+    orderedAt: '2026-03-18 16:44',
+    status: 'SHIPPED',
+  },
+  {
+    id: 'channel-order-4',
+    channel: 'AMAZON',
+    channelOrderNo: 'AMZ-4583208',
+    conkOrderNo: 'ORD-20260318-019',
+    recipient: '박서준',
+    itemsSummary: 'UV 선크림 SPF50 50ml',
+    orderAmount: 28,
+    orderedAt: '2026-03-18 15:05',
+    status: 'READY',
+  },
+  {
+    id: 'channel-order-5',
+    channel: 'MANUAL',
+    channelOrderNo: 'EXCEL-20260318-07',
+    conkOrderNo: 'ORD-20260318-017',
+    recipient: '정유진',
+    itemsSummary: '미스트 토닝 100ml 외 2건',
+    orderAmount: 75,
+    orderedAt: '2026-03-18 13:22',
+    status: 'DELIVERED',
+  },
+  {
+    id: 'channel-order-6',
+    channel: 'AMAZON',
+    channelOrderNo: 'AMZ-4583197',
+    conkOrderNo: 'ORD-20260318-010',
+    recipient: 'Sophia Kim',
+    itemsSummary: '히알루론 세럼 50ml',
+    orderAmount: 25,
+    orderedAt: '2026-03-18 09:18',
+    status: 'SHIPPED',
+  },
+]
+
+// 통합 주문 조회 테이블 렌더링에 사용하는 컬럼 정의.
+export const SELLER_CHANNEL_ORDER_COLUMNS = [
+  { key: 'channel', label: '채널', width: '110px' },
+  { key: 'channelOrderNo', label: '채널 주문번호', width: '150px' },
+  { key: 'conkOrderNo', label: 'CONK 주문번호', width: '150px' },
+  { key: 'recipient', label: '수령자', width: '130px' },
+  { key: 'itemsSummary', label: '주문 상품' },
+  { key: 'orderAmount', label: '주문 금액', width: '120px', align: 'right' },
+  { key: 'orderedAt', label: '주문일', width: '140px' },
+  { key: 'status', label: '처리 상태', width: '120px', align: 'center' },
+]
+
+// 채널 연결 카드 배지 표현을 반환한다.
+export function getSellerChannelSyncStatusMeta(status) {
+  return SELLER_CHANNEL_SYNC_STATUS_META[status] ?? { label: status ?? '-', tone: 'default' }
+}
+
+// 통합 주문 목록의 채널 배지 표현을 반환한다.
+export function getSellerChannelMeta(channel) {
+  return SELLER_CHANNEL_META[channel] ?? { label: channel ?? '-', tone: 'default' }
+}
+
+// 통합 주문 목록의 주문 상태 배지 표현을 반환한다.
+export function getSellerChannelOrderStatusMeta(status) {
+  return SELLER_CHANNEL_ORDER_STATUS_META[status] ?? { label: status ?? '-', tone: 'default' }
+}
+
+/**
+ * 채널 필터와 검색어를 함께 적용해 통합 주문 조회 목록을 만든다.
+ * 검색은 채널 주문번호, CONK 주문번호, 수령자, 상품명, 채널명을 함께 조회한다.
+ */
+export function filterSellerChannelOrderRows(
+  rows = [],
+  { channel = 'all', search = '' } = {},
+) {
+  const normalizedSearch = String(search).trim().toLowerCase()
+
+  return rows.filter((row) => {
+    const matchesChannel = channel === 'all' || row.channel === channel
+
+    if (!normalizedSearch) return matchesChannel
+
+    const haystack = [
+      row.channelOrderNo,
+      row.conkOrderNo,
+      row.recipient,
+      row.itemsSummary,
+      getSellerChannelMeta(row.channel).label,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+
+    return matchesChannel && haystack.includes(normalizedSearch)
+  })
+}

--- a/src/utils/marginSimulator.utils.js
+++ b/src/utils/marginSimulator.utils.js
@@ -1,0 +1,222 @@
+/**
+ * 셀러 마진 시뮬레이터 화면용 로컬 mock 데이터와 계산 유틸.
+ * 상품, 채널, 운송 조건을 바꿨을 때 수익성과 비용 구성을 즉시 계산한다.
+ */
+
+function toNumber(value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+// 마진 시뮬레이터에서 사용하는 채널 옵션.
+export const SELLER_MARGIN_CHANNEL_OPTIONS = [
+  { key: 'AMAZON', label: 'Amazon', defaultFeeRate: 15 },
+  { key: 'SHOPIFY', label: 'Shopify', defaultFeeRate: 3.2 },
+  { key: 'MANUAL', label: '수동', defaultFeeRate: 0 },
+]
+
+// 마진 시뮬레이터에서 사용하는 운송 방식 옵션.
+export const SELLER_MARGIN_SHIPPING_OPTIONS = [
+  { key: 'SEA', label: '해상' },
+  { key: 'AIR', label: '항공' },
+]
+
+// 상품 기본값과 물류비 기준이 함께 들어있는 상품 mock 데이터.
+export const SELLER_MARGIN_PRODUCT_OPTIONS = [
+  {
+    sku: 'LB-AMP-30',
+    productName: '루미에르 앰플 30ml',
+    defaultSalePrice: 34,
+    declaredValue: 8.6,
+    productCost: 6.8,
+    packagingCost: 0.7,
+    fulfillmentFee: 2.4,
+    seaShippingCost: 1.5,
+    airShippingCost: 3.8,
+    storageUnitCost: 0.16,
+  },
+  {
+    sku: 'LB-MSK-5P',
+    productName: '콜라겐 마스크 5매입',
+    defaultSalePrice: 18,
+    declaredValue: 4.4,
+    productCost: 3.1,
+    packagingCost: 0.35,
+    fulfillmentFee: 1.8,
+    seaShippingCost: 0.95,
+    airShippingCost: 2.3,
+    storageUnitCost: 0.1,
+  },
+  {
+    sku: 'LB-SUN-50',
+    productName: 'UV 선크림 SPF50 50ml',
+    defaultSalePrice: 28,
+    declaredValue: 6.2,
+    productCost: 5,
+    packagingCost: 0.5,
+    fulfillmentFee: 2.1,
+    seaShippingCost: 1.25,
+    airShippingCost: 3.1,
+    storageUnitCost: 0.14,
+  },
+]
+
+export function getMarginProductBySku(sku) {
+  return SELLER_MARGIN_PRODUCT_OPTIONS.find((item) => item.sku === sku) ?? null
+}
+
+export function getMarginChannelByKey(channelKey) {
+  return SELLER_MARGIN_CHANNEL_OPTIONS.find((item) => item.key === channelKey) ?? null
+}
+
+// 선택한 상품과 채널, 운송 모드에 맞는 기본 입력값을 만든다.
+export function createInitialMarginForm() {
+  const product = SELLER_MARGIN_PRODUCT_OPTIONS[0]
+  const channel = SELLER_MARGIN_CHANNEL_OPTIONS[0]
+
+  return {
+    productSku: product.sku,
+    salesChannel: channel.key,
+    shippingMode: 'SEA',
+    salePrice: product.defaultSalePrice,
+    channelFeeRate: channel.defaultFeeRate,
+    fulfillmentFee: product.fulfillmentFee,
+    internationalShippingFee: product.seaShippingCost,
+    otherCost: 120,
+    monthlySalesQty: 200,
+    storageUnitCost: product.storageUnitCost,
+    declaredValue: product.declaredValue,
+    dutyMode: 'rate',
+    vatRate: 10,
+    dutyRate: 8,
+    dutyAmount: 0,
+    productCost: product.productCost,
+    packagingCost: product.packagingCost,
+  }
+}
+
+// 선택한 상품과 운송 방식에 맞는 기본 국제 배송비를 반환한다.
+export function getProductShippingCost(product, shippingMode) {
+  if (!product) return 0
+  return shippingMode === 'AIR' ? product.airShippingCost : product.seaShippingCost
+}
+
+/**
+ * 시뮬레이터 입력값을 기반으로 예상 매출과 총 비용, 순이익, 마진율을 계산한다.
+ * 기타 비용은 월 고정비로 가정하고, 나머지 비용은 수량 기준 변동비로 계산한다.
+ */
+export function calculateMarginResult(form = {}) {
+  const salePrice = toNumber(form.salePrice)
+  const feeRate = toNumber(form.channelFeeRate)
+  const fulfillmentFee = toNumber(form.fulfillmentFee)
+  const internationalShippingFee = toNumber(form.internationalShippingFee)
+  const storageUnitCost = toNumber(form.storageUnitCost)
+  const monthlySalesQty = Math.max(1, toNumber(form.monthlySalesQty))
+  const declaredValue = toNumber(form.declaredValue)
+  const vatRate = toNumber(form.vatRate)
+  const dutyRate = toNumber(form.dutyRate)
+  const dutyAmount = toNumber(form.dutyAmount)
+  const productCost = toNumber(form.productCost)
+  const packagingCost = toNumber(form.packagingCost)
+  const otherCost = toNumber(form.otherCost)
+
+  const revenue = salePrice * monthlySalesQty
+  const channelFee = revenue * (feeRate / 100)
+  const fulfillmentCost = fulfillmentFee * monthlySalesQty
+  const shippingCost = internationalShippingFee * monthlySalesQty
+  const storageCost = storageUnitCost * monthlySalesQty
+  const productCostTotal = productCost * monthlySalesQty
+  const packagingCostTotal = packagingCost * monthlySalesQty
+  const declaredTotal = declaredValue * monthlySalesQty
+  const customsDuty =
+    form.dutyMode === 'amount'
+      ? dutyAmount * monthlySalesQty
+      : declaredTotal * (dutyRate / 100)
+  const vatCost = (declaredTotal + customsDuty) * (vatRate / 100)
+
+  const totalCost =
+    channelFee +
+    fulfillmentCost +
+    shippingCost +
+    storageCost +
+    productCostTotal +
+    packagingCostTotal +
+    customsDuty +
+    vatCost +
+    otherCost
+
+  const netProfit = revenue - totalCost
+  const marginRate = revenue > 0 ? (netProfit / revenue) * 100 : 0
+
+  const perUnitDuty = customsDuty / monthlySalesQty
+  const perUnitVat = vatCost / monthlySalesQty
+  const variableUnitCost =
+    salePrice * (feeRate / 100) +
+    fulfillmentFee +
+    internationalShippingFee +
+    storageUnitCost +
+    productCost +
+    packagingCost +
+    perUnitDuty +
+    perUnitVat
+  const unitContribution = salePrice - variableUnitCost
+  const breakEvenUnits = unitContribution > 0 ? Math.ceil(otherCost / unitContribution) : null
+
+  const breakdown = [
+    { key: 'channelFee', label: '채널 수수료', value: channelFee, tone: 'gold' },
+    { key: 'fulfillmentCost', label: '풀필먼트 수수료', value: fulfillmentCost, tone: 'blue' },
+    { key: 'shippingCost', label: '국제 배송비', value: shippingCost, tone: 'purple' },
+    { key: 'storageCost', label: '보관비', value: storageCost, tone: 'green' },
+    { key: 'productCost', label: '매입 원가', value: productCostTotal, tone: 'red' },
+    { key: 'packagingCost', label: '포장비', value: packagingCostTotal, tone: 'amber' },
+    { key: 'customsDuty', label: '관세', value: customsDuty, tone: 'blue' },
+    { key: 'vatCost', label: '부가세', value: vatCost, tone: 'purple' },
+    { key: 'otherCost', label: '기타 비용', value: otherCost, tone: 'default' },
+  ]
+
+  return {
+    revenue,
+    totalCost,
+    netProfit,
+    marginRate,
+    breakEvenUnits,
+    breakdown,
+  }
+}
+
+// 현재 설정과 해상/항공 기준을 함께 비교할 수 있게 시나리오 카드를 만든다.
+export function buildMarginScenarioCards(form = {}) {
+  const product = getMarginProductBySku(form.productSku)
+
+  const seaForm = {
+    ...form,
+    shippingMode: 'SEA',
+    internationalShippingFee: getProductShippingCost(product, 'SEA'),
+  }
+  const airForm = {
+    ...form,
+    shippingMode: 'AIR',
+    internationalShippingFee: getProductShippingCost(product, 'AIR'),
+  }
+
+  return [
+    {
+      key: 'SEA_BASE',
+      label: '해상 기준',
+      shippingLabel: '해상',
+      ...calculateMarginResult(seaForm),
+    },
+    {
+      key: 'CURRENT',
+      label: '현재 설정',
+      shippingLabel: form.shippingMode === 'AIR' ? '항공' : '해상',
+      ...calculateMarginResult(form),
+    },
+    {
+      key: 'AIR_BASE',
+      label: '항공 기준',
+      shippingLabel: '항공',
+      ...calculateMarginResult(airForm),
+    },
+  ]
+}

--- a/src/utils/notifications.utils.js
+++ b/src/utils/notifications.utils.js
@@ -1,0 +1,102 @@
+/**
+ * 셀러 알림 화면용 로컬 mock 데이터와 가공 유틸.
+ * 안읽음 필터, 유형 필터, 전체 읽음 처리 흐름을 API 없이 먼저 검증한다.
+ */
+
+// 알림 유형별 라벨, 색상, 아이콘 메타 정보.
+export const SELLER_NOTIFICATION_TYPE_META = {
+  ASN_RECEIVED: { label: '입고 완료', tone: 'blue', icon: '↓' },
+  LOW_STOCK: { label: '재고 부족', tone: 'amber', icon: '!' },
+  ORDER_SHIPPED: { label: '출고 완료', tone: 'green', icon: '↑' },
+  QTY_MISMATCH: { label: '수량 불일치', tone: 'red', icon: '≠' },
+  INVOICE_ISSUED: { label: '송장 발행', tone: 'purple', icon: '#' },
+}
+
+// 알림 목록 상단 필터 값.
+export const SELLER_NOTIFICATION_FILTER_OPTIONS = [
+  { key: 'all', label: '전체' },
+  { key: 'unread', label: '안읽음' },
+  { key: 'ASN_RECEIVED', label: '입고 완료' },
+  { key: 'LOW_STOCK', label: '재고 부족' },
+  { key: 'ORDER_SHIPPED', label: '출고 완료' },
+  { key: 'QTY_MISMATCH', label: '수량 불일치' },
+  { key: 'INVOICE_ISSUED', label: '송장 발행' },
+]
+
+// 알림 목록 화면 mock 원본 데이터.
+export const SELLER_NOTIFICATION_ROWS = [
+  {
+    id: 'seller-notification-1',
+    type: 'ASN_RECEIVED',
+    title: 'ASN-20260319-0003 입고가 완료되었습니다.',
+    body: 'ICN-A 창고에서 루미에르 앰플 외 18 SKU 검수가 완료되었습니다.',
+    timeLabel: '방금',
+    read: false,
+  },
+  {
+    id: 'seller-notification-2',
+    type: 'LOW_STOCK',
+    title: '재고 부족 상품이 감지되었습니다.',
+    body: 'LB-SUN-50 SKU의 가용재고가 경고 임계치 10개 아래로 내려갔습니다.',
+    timeLabel: '5분 전',
+    read: false,
+  },
+  {
+    id: 'seller-notification-3',
+    type: 'ORDER_SHIPPED',
+    title: 'AMZ-4583197 주문이 출고 완료되었습니다.',
+    body: '택배사 인계가 끝나 송장 조회가 가능합니다.',
+    timeLabel: '32분 전',
+    read: false,
+  },
+  {
+    id: 'seller-notification-4',
+    type: 'QTY_MISMATCH',
+    title: '입고 수량 불일치가 확인되었습니다.',
+    body: 'ASN-20260318-0011에서 신고 수량과 실제 검수 수량에 차이가 있습니다.',
+    timeLabel: '1시간 전',
+    read: true,
+  },
+  {
+    id: 'seller-notification-5',
+    type: 'INVOICE_ISSUED',
+    title: '송장이 발행되었습니다.',
+    body: 'ORD-20260318-021 주문에 UPS 송장번호 1Z-28403이 연결되었습니다.',
+    timeLabel: '어제',
+    read: true,
+  },
+  {
+    id: 'seller-notification-6',
+    type: 'LOW_STOCK',
+    title: '마스크팩 재고가 부족합니다.',
+    body: 'LB-MSK-5P SKU가 오늘 예상 판매량 대비 부족 상태입니다.',
+    timeLabel: '2일 전',
+    read: true,
+  },
+]
+
+export function getSellerNotificationTypeMeta(type) {
+  return SELLER_NOTIFICATION_TYPE_META[type] ?? { label: type ?? '-', tone: 'default', icon: '•' }
+}
+
+export function countUnreadNotifications(rows = []) {
+  return rows.filter((row) => !row.read).length
+}
+
+export function countNotificationsByFilter(rows = [], filter = 'all') {
+  return filterSellerNotifications(rows, { filter }).length
+}
+
+// 선택한 필터 기준으로 알림 목록을 추린다.
+export function filterSellerNotifications(rows = [], { filter = 'all' } = {}) {
+  return rows.filter((row) => {
+    if (filter === 'all') return true
+    if (filter === 'unread') return !row.read
+    return row.type === filter
+  })
+}
+
+// 전체 읽음 처리는 원본 배열을 바꾸지 않고 읽음 상태만 갱신한 새 배열을 만든다.
+export function markAllNotificationsRead(rows = []) {
+  return rows.map((row) => ({ ...row, read: true }))
+}

--- a/src/views/seller/SellerChannelOrdersView.vue
+++ b/src/views/seller/SellerChannelOrdersView.vue
@@ -1,0 +1,462 @@
+<script setup>
+/**
+ * 셀러 주문 연동 및 조회 화면.
+ * 채널 연결 카드와 통합 주문 목록을 로컬 mock 데이터 기준으로 먼저 구성한다.
+ */
+import { computed, ref, watch } from 'vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import BaseTable from '@/components/common/BaseTable.vue'
+import {
+  filterSellerChannelOrderRows,
+  getSellerChannelMeta,
+  getSellerChannelOrderStatusMeta,
+  getSellerChannelSyncStatusMeta,
+  SELLER_CHANNEL_FILTER_OPTIONS,
+  SELLER_CHANNEL_ORDER_COLUMNS,
+  SELLER_CHANNEL_ORDER_ROWS,
+  SELLER_CHANNEL_SYNC_CARDS,
+} from '@/utils/channelOrders.utils.js'
+
+const breadcrumb = [{ label: 'Seller' }, { label: '주문 연동 및 조회' }]
+
+// 채널 필터, 검색어, 툴바 안내 메시지를 페이지 로컬 상태로 관리한다.
+const activeChannel = ref('all')
+const searchKeyword = ref('')
+const toolbarMessage = ref('')
+
+// 페이지네이션은 로컬 mock 기준으로 단순 처리한다.
+const currentPage = ref(1)
+const PAGE_SIZE = 6
+
+watch([activeChannel, searchKeyword], () => {
+  currentPage.value = 1
+})
+
+// 선택한 채널과 검색어를 기준으로 통합 주문 목록을 필터링한다.
+const filteredRows = computed(() => {
+  return filterSellerChannelOrderRows(SELLER_CHANNEL_ORDER_ROWS, {
+    channel: activeChannel.value,
+    search: searchKeyword.value,
+  })
+})
+
+const pagedRows = computed(() => {
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filteredRows.value.slice(start, start + PAGE_SIZE)
+})
+
+const pagination = computed(() => ({
+  page: currentPage.value,
+  pageSize: PAGE_SIZE,
+  total: filteredRows.value.length,
+}))
+
+function handlePageChange(page) {
+  currentPage.value = page
+}
+
+// UI 단계라 버튼 클릭은 동기화/가져오기/내보내기 안내 메시지로 처리한다.
+// TODO(frontend): 채널 동기화, 주문 가져오기, 내보내기 실동작을 연결한다.
+function showToolbarMessage(message) {
+  toolbarMessage.value = message
+}
+</script>
+
+<template>
+  <AppLayout title="주문 연동 및 조회" :breadcrumb="breadcrumb">
+    <section class="seller-channel-orders-page">
+      <div class="channel-grid">
+        <article
+          v-for="card in SELLER_CHANNEL_SYNC_CARDS"
+          :key="card.key"
+          class="channel-card"
+        >
+          <div class="channel-card-head">
+            <div>
+              <p class="channel-label">{{ card.label }}</p>
+              <strong class="channel-title">채널 연결 현황</strong>
+            </div>
+
+            <span
+              class="sync-badge"
+              :class="`sync-badge--${getSellerChannelSyncStatusMeta(card.syncStatus).tone}`"
+            >
+              {{ getSellerChannelSyncStatusMeta(card.syncStatus).label }}
+            </span>
+          </div>
+
+          <p class="channel-description">{{ card.description }}</p>
+
+          <div class="channel-kpi-grid">
+            <div class="channel-kpi">
+              <span class="channel-kpi-label">미처리 주문</span>
+              <strong class="channel-kpi-value">{{ card.pendingOrders }}</strong>
+            </div>
+
+            <div class="channel-kpi">
+              <span class="channel-kpi-label">오늘 신규</span>
+              <strong class="channel-kpi-value">{{ card.todayImported }}</strong>
+            </div>
+          </div>
+
+          <p class="channel-sync-text">마지막 동기화 {{ card.lastSyncedAt }}</p>
+
+          <div class="channel-actions">
+            <button
+              v-for="action in card.actions"
+              :key="action.key"
+              type="button"
+              class="channel-action-btn"
+              :class="{
+                'channel-action-btn--ghost': action.variant === 'ghost',
+                'channel-action-btn--primary': action.variant === 'primary',
+              }"
+              :disabled="action.disabled"
+              @click="showToolbarMessage(`${card.label} ${action.label} UI는 다음 단계에서 연결합니다.`)"
+            >
+              {{ action.label }}
+            </button>
+          </div>
+        </article>
+      </div>
+
+      <section class="list-card">
+        <div class="list-head">
+          <div>
+            <p class="section-eyebrow">Channel Order Monitor</p>
+            <h2 class="section-title">채널 통합 주문 조회</h2>
+          </div>
+
+          <div class="toolbar-right">
+            <label class="search-box">
+              <input
+                v-model="searchKeyword"
+                type="text"
+                placeholder="주문번호 / 수령자 검색"
+              />
+            </label>
+
+            <!-- TODO(frontend): 통합 주문 내보내기 기능을 연결한다. -->
+            <button
+              class="ui-btn ui-btn--ghost toolbar-btn"
+              type="button"
+              @click="showToolbarMessage('통합 주문 내보내기 UI는 다음 단계에서 연결합니다.')"
+            >
+              내보내기
+            </button>
+          </div>
+        </div>
+
+        <div class="filter-row">
+          <button
+            v-for="option in SELLER_CHANNEL_FILTER_OPTIONS"
+            :key="option.key"
+            type="button"
+            class="filter-badge"
+            :class="{ 'filter-badge--active': activeChannel === option.key }"
+            @click="activeChannel = option.key"
+          >
+            {{ option.label }}
+          </button>
+        </div>
+
+        <p v-if="toolbarMessage" class="toolbar-message">{{ toolbarMessage }}</p>
+
+        <BaseTable
+          :columns="SELLER_CHANNEL_ORDER_COLUMNS"
+          :rows="pagedRows"
+          :pagination="pagination"
+          row-key="id"
+          @page-change="handlePageChange"
+        >
+          <template #cell-channel="{ value }">
+            <span
+              class="channel-badge"
+              :class="`channel-badge--${getSellerChannelMeta(value).tone}`"
+            >
+              {{ getSellerChannelMeta(value).label }}
+            </span>
+          </template>
+
+          <template #cell-channelOrderNo="{ value }">
+            <span class="order-code">{{ value }}</span>
+          </template>
+
+          <template #cell-conkOrderNo="{ value }">
+            <span class="order-code">{{ value }}</span>
+          </template>
+
+          <template #cell-orderAmount="{ value }">
+            ${{ value.toFixed(2) }}
+          </template>
+
+          <template #cell-status="{ value }">
+            <span
+              class="order-status-badge"
+              :class="`order-status-badge--${getSellerChannelOrderStatusMeta(value).tone}`"
+            >
+              {{ getSellerChannelOrderStatusMeta(value).label }}
+            </span>
+          </template>
+        </BaseTable>
+      </section>
+    </section>
+  </AppLayout>
+</template>
+
+<style scoped>
+.seller-channel-orders-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.channel-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.channel-card,
+.list-card {
+  padding: var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.channel-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.channel-card-head,
+.list-head {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+
+.channel-label,
+.section-eyebrow {
+  margin: 0 0 var(--space-2);
+  color: var(--blue);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.channel-title,
+.section-title {
+  margin: 0;
+  color: var(--t1);
+  font-size: var(--font-size-xl);
+}
+
+.sync-badge,
+.channel-badge,
+.order-status-badge,
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.sync-badge--gold,
+.channel-badge--gold {
+  background: var(--gold-pale);
+  color: #b45309;
+}
+
+.sync-badge--green,
+.order-status-badge--green {
+  background: var(--green-pale);
+  color: var(--green);
+}
+
+.sync-badge--red {
+  background: var(--red-pale);
+  color: var(--red);
+}
+
+.channel-badge--blue,
+.order-status-badge--blue {
+  background: var(--blue-pale);
+  color: var(--blue);
+}
+
+.channel-badge--red {
+  background: var(--red-pale);
+  color: var(--red);
+}
+
+.channel-badge--default {
+  background: var(--surface-2);
+  color: var(--t3);
+}
+
+.order-status-badge--amber {
+  background: var(--amber-pale);
+  color: #b45309;
+}
+
+.order-status-badge--purple {
+  background: var(--purple-pale);
+  color: var(--purple);
+}
+
+.channel-description,
+.channel-sync-text {
+  margin: 0;
+  color: var(--t2);
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+}
+
+.channel-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.channel-kpi {
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+}
+
+.channel-kpi-label {
+  display: block;
+  margin-bottom: var(--space-2);
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+}
+
+.channel-kpi-value {
+  color: var(--t1);
+  font-family: var(--font-condensed);
+  font-size: var(--font-size-2xl);
+}
+
+.channel-actions,
+.toolbar-right,
+.filter-row {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.channel-actions,
+.filter-row {
+  flex-wrap: wrap;
+}
+
+.toolbar-right {
+  flex-wrap: nowrap;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.channel-action-btn {
+  min-width: 108px;
+  height: 38px;
+  padding: 0 16px;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.channel-action-btn--ghost {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--t2);
+}
+
+.channel-action-btn--primary {
+  border: 1px solid var(--gold);
+  background: var(--gold);
+  color: var(--t1);
+}
+
+.list-head {
+  margin-bottom: var(--space-4);
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  flex: 0 0 260px;
+  width: 260px;
+  height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+}
+
+.search-box input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--t1);
+  font-size: var(--font-size-sm);
+}
+
+.toolbar-btn {
+  flex-shrink: 0;
+  min-width: 92px;
+}
+
+.filter-row {
+  margin-bottom: var(--space-4);
+}
+
+.filter-badge {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--t3);
+  cursor: pointer;
+}
+
+.filter-badge--active {
+  border-color: var(--gold);
+  background: var(--gold-pale);
+  color: var(--t1);
+}
+
+.toolbar-message {
+  margin: 0 0 var(--space-4);
+  color: var(--blue);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.order-code {
+  color: var(--t1);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 1180px) {
+  .channel-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .list-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>

--- a/src/views/seller/SellerMarginSimulatorView.vue
+++ b/src/views/seller/SellerMarginSimulatorView.vue
@@ -1,0 +1,618 @@
+<script setup>
+/**
+ * 셀러 마진 시뮬레이터 화면.
+ * 상품, 채널, 운송 조건을 바꾸면 우측 수익성과 비용 구성이 즉시 갱신된다.
+ */
+import { computed, reactive, watch } from 'vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import BaseForm from '@/components/common/BaseForm.vue'
+import {
+  buildMarginScenarioCards,
+  calculateMarginResult,
+  createInitialMarginForm,
+  getMarginChannelByKey,
+  getMarginProductBySku,
+  getProductShippingCost,
+  SELLER_MARGIN_CHANNEL_OPTIONS,
+  SELLER_MARGIN_PRODUCT_OPTIONS,
+  SELLER_MARGIN_SHIPPING_OPTIONS,
+} from '@/utils/marginSimulator.utils.js'
+
+const breadcrumb = [{ label: 'Seller' }, { label: '마진 시뮬레이터' }]
+
+// TODO(frontend): 상품별 실제 비용 기준과 채널 수수료 preset API를 연결한다.
+// 시뮬레이터 입력값은 현재 화면에서만 유지한다.
+const form = reactive(createInitialMarginForm())
+
+const currentProduct = computed(() => getMarginProductBySku(form.productSku))
+const result = computed(() => calculateMarginResult(form))
+const scenarioCards = computed(() => buildMarginScenarioCards(form))
+const maxBreakdownValue = computed(() => {
+  return Math.max(...result.value.breakdown.map((item) => item.value), 1)
+})
+
+function formatUsd(value) {
+  return `$${Number(value || 0).toFixed(2)}`
+}
+
+function formatPercent(value) {
+  return `${Number(value || 0).toFixed(1)}%`
+}
+
+// 상품이 바뀌면 원가, 신고가, 기본 물류비 같은 추천값을 다시 불러온다.
+watch(
+  () => form.productSku,
+  (sku) => {
+    const product = getMarginProductBySku(sku)
+    if (!product) return
+
+    form.salePrice = product.defaultSalePrice
+    form.fulfillmentFee = product.fulfillmentFee
+    form.storageUnitCost = product.storageUnitCost
+    form.declaredValue = product.declaredValue
+    form.productCost = product.productCost
+    form.packagingCost = product.packagingCost
+    form.internationalShippingFee = getProductShippingCost(product, form.shippingMode)
+  },
+)
+
+// 채널이 바뀌면 해당 채널 기본 수수료율을 다시 불러온다.
+watch(
+  () => form.salesChannel,
+  (channelKey) => {
+    const channel = getMarginChannelByKey(channelKey)
+    if (!channel) return
+    form.channelFeeRate = channel.defaultFeeRate
+  },
+)
+
+// 운송 방식이 바뀌면 선택한 상품 기준 기본 국제 배송비를 다시 반영한다.
+watch(
+  () => form.shippingMode,
+  (shippingMode) => {
+    form.internationalShippingFee = getProductShippingCost(currentProduct.value, shippingMode)
+  },
+)
+
+function resetForm() {
+  Object.assign(form, createInitialMarginForm())
+}
+</script>
+
+<template>
+  <AppLayout title="마진 시뮬레이터" :breadcrumb="breadcrumb">
+    <section class="seller-margin-simulator-page">
+      <div class="simulator-grid">
+        <div class="form-panel">
+          <section class="panel-card">
+            <header class="panel-header">
+              <div>
+                <p class="section-eyebrow">Margin Inputs</p>
+                <h2 class="section-title">상품 선택</h2>
+              </div>
+            </header>
+
+            <div class="form-grid">
+              <BaseForm label="상품 SKU" required>
+                <select v-model="form.productSku">
+                  <option
+                    v-for="product in SELLER_MARGIN_PRODUCT_OPTIONS"
+                    :key="product.sku"
+                    :value="product.sku"
+                  >
+                    {{ product.sku }} · {{ product.productName }}
+                  </option>
+                </select>
+              </BaseForm>
+
+              <BaseForm label="판매 채널" required>
+                <select v-model="form.salesChannel">
+                  <option
+                    v-for="channel in SELLER_MARGIN_CHANNEL_OPTIONS"
+                    :key="channel.key"
+                    :value="channel.key"
+                  >
+                    {{ channel.label }}
+                  </option>
+                </select>
+              </BaseForm>
+
+              <BaseForm label="운송 모드" required>
+                <select v-model="form.shippingMode">
+                  <option
+                    v-for="option in SELLER_MARGIN_SHIPPING_OPTIONS"
+                    :key="option.key"
+                    :value="option.key"
+                  >
+                    {{ option.label }}
+                  </option>
+                </select>
+              </BaseForm>
+            </div>
+          </section>
+
+          <section class="panel-card">
+            <header class="panel-header">
+              <h2 class="panel-title">판매 정보</h2>
+            </header>
+
+            <div class="form-grid">
+              <BaseForm label="판매가 (USD)" required>
+                <input v-model="form.salePrice" type="number" min="0" step="0.01" />
+              </BaseForm>
+
+              <BaseForm label="채널 수수료율 (%)" required>
+                <input v-model="form.channelFeeRate" type="number" min="0" step="0.1" />
+              </BaseForm>
+            </div>
+          </section>
+
+          <section class="panel-card">
+            <header class="panel-header">
+              <h2 class="panel-title">물류비 (USD)</h2>
+            </header>
+
+            <div class="form-grid">
+              <BaseForm label="CONK 풀필먼트 수수료" required>
+                <input v-model="form.fulfillmentFee" type="number" min="0" step="0.01" />
+              </BaseForm>
+
+              <BaseForm label="기준 국제 배송비" required>
+                <input v-model="form.internationalShippingFee" type="number" min="0" step="0.01" />
+              </BaseForm>
+
+              <BaseForm label="월 기타 비용">
+                <input v-model="form.otherCost" type="number" min="0" step="0.01" />
+              </BaseForm>
+
+              <BaseForm label="월 예상 판매 수량" required>
+                <input v-model="form.monthlySalesQty" type="number" min="1" step="1" />
+              </BaseForm>
+
+              <BaseForm label="보관비 단가" required>
+                <input v-model="form.storageUnitCost" type="number" min="0" step="0.01" />
+              </BaseForm>
+            </div>
+          </section>
+
+          <section class="panel-card">
+            <header class="panel-header">
+              <h2 class="panel-title">통관 비용</h2>
+            </header>
+
+            <div class="form-grid">
+              <BaseForm label="신고가 기준" required>
+                <input v-model="form.declaredValue" type="number" min="0" step="0.01" />
+              </BaseForm>
+
+              <BaseForm label="관세 입력 방식" required>
+                <select v-model="form.dutyMode">
+                  <option value="rate">관세율</option>
+                  <option value="amount">관세액 직접 입력</option>
+                </select>
+              </BaseForm>
+
+              <BaseForm label="부가세율 (%)" required>
+                <input v-model="form.vatRate" type="number" min="0" step="0.1" />
+              </BaseForm>
+
+              <BaseForm v-if="form.dutyMode === 'rate'" label="관세율 (%)" required>
+                <input v-model="form.dutyRate" type="number" min="0" step="0.1" />
+              </BaseForm>
+
+              <BaseForm v-else label="관세액 직접 입력" required>
+                <input v-model="form.dutyAmount" type="number" min="0" step="0.01" />
+              </BaseForm>
+            </div>
+          </section>
+
+          <section class="panel-card">
+            <header class="panel-header">
+              <h2 class="panel-title">원가</h2>
+            </header>
+
+            <div class="form-grid">
+              <BaseForm label="매입 원가" required>
+                <input v-model="form.productCost" type="number" min="0" step="0.01" />
+              </BaseForm>
+
+              <BaseForm label="포장비" required>
+                <input v-model="form.packagingCost" type="number" min="0" step="0.01" />
+              </BaseForm>
+            </div>
+
+            <div class="panel-actions">
+              <button class="ui-btn ui-btn--ghost" type="button" @click="resetForm">
+                기본값 복원
+              </button>
+            </div>
+          </section>
+        </div>
+
+        <div class="result-panel">
+          <article class="summary-card">
+            <p class="summary-eyebrow">Estimated Result</p>
+            <h2 class="summary-title">{{ currentProduct?.productName ?? '선택된 상품 없음' }}</h2>
+
+            <div class="summary-grid">
+              <div class="summary-item">
+                <span class="summary-label">예상 매출</span>
+                <strong class="summary-value">{{ formatUsd(result.revenue) }}</strong>
+              </div>
+
+              <div class="summary-item">
+                <span class="summary-label">총 비용</span>
+                <strong class="summary-value">{{ formatUsd(result.totalCost) }}</strong>
+              </div>
+
+              <div class="summary-item">
+                <span class="summary-label">순이익</span>
+                <strong class="summary-value">{{ formatUsd(result.netProfit) }}</strong>
+              </div>
+
+              <div class="summary-item">
+                <span class="summary-label">마진율</span>
+                <strong class="summary-value">{{ formatPercent(result.marginRate) }}</strong>
+              </div>
+            </div>
+
+            <div class="summary-bep">
+              <span>손익분기점 (BEP)</span>
+              <strong>{{ result.breakEvenUnits ? `${result.breakEvenUnits}개` : '달성 불가' }}</strong>
+            </div>
+          </article>
+
+          <article class="panel-card">
+            <header class="panel-header">
+              <h2 class="panel-title">수익 구조 분해</h2>
+            </header>
+
+            <div class="breakdown-list">
+              <div v-for="item in result.breakdown" :key="item.key" class="breakdown-item">
+                <div class="breakdown-row">
+                  <span class="breakdown-label">{{ item.label }}</span>
+                  <strong class="breakdown-value">{{ formatUsd(item.value) }}</strong>
+                </div>
+
+                <div class="breakdown-track">
+                  <div
+                    class="breakdown-bar"
+                    :class="`breakdown-bar--${item.tone}`"
+                    :style="{ width: `${(item.value / maxBreakdownValue) * 100}%` }"
+                  />
+                </div>
+              </div>
+            </div>
+          </article>
+
+          <article class="panel-card">
+            <header class="panel-header">
+              <h2 class="panel-title">비용 상세 내역</h2>
+            </header>
+
+            <table class="detail-table">
+              <thead>
+                <tr>
+                  <th>항목</th>
+                  <th>금액</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in result.breakdown" :key="item.key">
+                  <td>{{ item.label }}</td>
+                  <td>{{ formatUsd(item.value) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+
+          <article class="panel-card">
+            <header class="panel-header">
+              <h2 class="panel-title">시나리오 비교</h2>
+            </header>
+
+            <div class="scenario-grid">
+              <div
+                v-for="scenario in scenarioCards"
+                :key="scenario.key"
+                class="scenario-card"
+                :class="{ 'scenario-card--negative': scenario.netProfit < 0 }"
+              >
+                <span class="scenario-label">{{ scenario.label }}</span>
+                <strong class="scenario-value">{{ formatUsd(scenario.netProfit) }}</strong>
+                <span class="scenario-meta">
+                  {{ scenario.shippingLabel }} · {{ formatPercent(scenario.marginRate) }}
+                </span>
+              </div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </AppLayout>
+</template>
+
+<style scoped>
+.seller-margin-simulator-page {
+  display: flex;
+  flex-direction: column;
+}
+
+.simulator-grid {
+  display: grid;
+  grid-template-columns: minmax(360px, 480px) minmax(0, 1fr);
+  gap: var(--space-5);
+}
+
+.form-panel,
+.result-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.panel-card {
+  padding: var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.section-eyebrow {
+  margin: 0 0 var(--space-2);
+  color: var(--blue);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-title,
+.panel-title {
+  margin: 0;
+  color: var(--t1);
+  font-size: var(--font-size-lg);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+:deep(.field-control input),
+:deep(.field-control select),
+.form-grid input,
+.form-grid select {
+  width: 100%;
+  height: 40px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--t1);
+  font-size: var(--font-size-sm);
+}
+
+.form-grid input:focus,
+.form-grid select:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--blue-pale);
+}
+
+.panel-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--space-4);
+}
+
+.summary-card {
+  padding: var(--space-6);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(140deg, #1a1a2e 0%, #252540 100%);
+  color: #fff;
+  box-shadow: var(--shadow-md);
+}
+
+.summary-eyebrow {
+  margin: 0 0 var(--space-2);
+  color: rgba(255, 255, 255, 0.7);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.summary-title {
+  margin: 0 0 var(--space-5);
+  font-family: var(--font-condensed);
+  font-size: 28px;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.summary-item {
+  padding: var(--space-4);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.summary-label {
+  display: block;
+  margin-bottom: var(--space-2);
+  color: rgba(255, 255, 255, 0.72);
+  font-size: var(--font-size-sm);
+}
+
+.summary-value {
+  font-family: var(--font-condensed);
+  font-size: 30px;
+}
+
+.summary-bep {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: var(--font-size-sm);
+}
+
+.summary-bep strong {
+  font-size: var(--font-size-lg);
+}
+
+.breakdown-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+.breakdown-label {
+  color: var(--t2);
+  font-size: var(--font-size-sm);
+}
+
+.breakdown-value {
+  color: var(--t1);
+  font-size: var(--font-size-sm);
+}
+
+.breakdown-track {
+  width: 100%;
+  height: 10px;
+  border-radius: var(--radius-full);
+  background: var(--surface-2);
+  overflow: hidden;
+}
+
+.breakdown-bar {
+  height: 100%;
+  border-radius: inherit;
+}
+
+.breakdown-bar--gold {
+  background: var(--gold);
+}
+
+.breakdown-bar--blue {
+  background: var(--blue);
+}
+
+.breakdown-bar--purple {
+  background: var(--purple);
+}
+
+.breakdown-bar--green {
+  background: var(--green);
+}
+
+.breakdown-bar--red {
+  background: var(--red);
+}
+
+.breakdown-bar--amber {
+  background: var(--amber);
+}
+
+.breakdown-bar--default {
+  background: var(--t4);
+}
+
+.detail-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.detail-table th,
+.detail-table td {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  font-size: var(--font-size-sm);
+}
+
+.detail-table th:last-child,
+.detail-table td:last-child {
+  text-align: right;
+}
+
+.detail-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.scenario-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.scenario-card {
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+}
+
+.scenario-card--negative {
+  border-color: var(--red);
+  background: var(--red-pale);
+}
+
+.scenario-label {
+  display: block;
+  margin-bottom: var(--space-2);
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.scenario-value {
+  display: block;
+  margin-bottom: var(--space-2);
+  color: var(--t1);
+  font-family: var(--font-condensed);
+  font-size: 24px;
+}
+
+.scenario-meta {
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 1240px) {
+  .simulator-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 820px) {
+  .form-grid,
+  .summary-grid,
+  .scenario-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/seller/SellerNotificationsView.vue
+++ b/src/views/seller/SellerNotificationsView.vue
@@ -1,0 +1,365 @@
+<script setup>
+/**
+ * 셀러 알림 화면.
+ * 안읽음 필터와 전체 읽음 처리, 더 보기 흐름을 로컬 mock 데이터로 먼저 구성한다.
+ */
+import { computed, ref, watch } from 'vue'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import {
+  countNotificationsByFilter,
+  countUnreadNotifications,
+  filterSellerNotifications,
+  getSellerNotificationTypeMeta,
+  markAllNotificationsRead,
+  SELLER_NOTIFICATION_FILTER_OPTIONS,
+  SELLER_NOTIFICATION_ROWS,
+} from '@/utils/notifications.utils.js'
+
+const breadcrumb = [{ label: 'Seller' }, { label: '알림' }]
+
+// TODO(frontend): 알림 store 또는 API와 연결해 실제 읽음 상태를 반영한다.
+// 알림은 로컬 mock 데이터를 복사해 읽음 상태를 이 화면 안에서만 바꾼다.
+const notifications = ref(SELLER_NOTIFICATION_ROWS.map((item) => ({ ...item })))
+const activeFilter = ref('all')
+const feedbackMessage = ref('')
+const visibleCount = ref(5)
+
+watch(activeFilter, () => {
+  visibleCount.value = 5
+  feedbackMessage.value = ''
+})
+
+const filterOptions = computed(() => {
+  return SELLER_NOTIFICATION_FILTER_OPTIONS.map((option) => ({
+    ...option,
+    count: countNotificationsByFilter(notifications.value, option.key),
+  }))
+})
+
+const unreadCount = computed(() => countUnreadNotifications(notifications.value))
+
+const filteredRows = computed(() => {
+  return filterSellerNotifications(notifications.value, {
+    filter: activeFilter.value,
+  })
+})
+
+const visibleRows = computed(() => filteredRows.value.slice(0, visibleCount.value))
+
+function handleMarkAllRead() {
+  notifications.value = markAllNotificationsRead(notifications.value)
+  feedbackMessage.value = '전체 알림을 읽음 처리했습니다.'
+}
+
+function handleNotificationClick(id) {
+  notifications.value = notifications.value.map((item) => {
+    if (item.id !== id || item.read) return item
+    return { ...item, read: true }
+  })
+}
+
+function handleLoadMore() {
+  if (visibleCount.value >= filteredRows.value.length) {
+    feedbackMessage.value = '더 표시할 알림이 없습니다.'
+    return
+  }
+
+  visibleCount.value += 5
+}
+</script>
+
+<template>
+  <AppLayout title="알림" :breadcrumb="breadcrumb">
+    <section class="seller-notifications-page">
+      <section class="list-card">
+        <div class="toolbar">
+          <div class="filter-group">
+            <button
+              v-for="option in filterOptions"
+              :key="option.key"
+              type="button"
+              class="filter-badge"
+              :class="{ 'filter-badge--active': activeFilter === option.key }"
+              @click="activeFilter = option.key"
+            >
+              <span>{{ option.label }}</span>
+              <strong>{{ option.count }}</strong>
+            </button>
+          </div>
+
+          <button class="ui-btn ui-btn--ghost" type="button" @click="handleMarkAllRead">
+            전체 읽음 처리
+          </button>
+        </div>
+
+        <div class="summary-strip">
+          <span class="summary-text">안읽음 {{ unreadCount }}건</span>
+          <span class="summary-text">최근 7일 알림 흐름을 먼저 확인합니다.</span>
+        </div>
+
+        <p v-if="feedbackMessage" class="toolbar-message">{{ feedbackMessage }}</p>
+
+        <div class="notification-list">
+          <button
+            v-for="item in visibleRows"
+            :key="item.id"
+            type="button"
+            class="notification-item"
+            :class="{ 'notification-item--unread': !item.read }"
+            @click="handleNotificationClick(item.id)"
+          >
+            <div
+              class="notification-icon"
+              :class="`notification-icon--${getSellerNotificationTypeMeta(item.type).tone}`"
+            >
+              {{ getSellerNotificationTypeMeta(item.type).icon }}
+            </div>
+
+            <div class="notification-content">
+              <div class="notification-top">
+                <div class="notification-title-wrap">
+                  <span
+                    class="notification-type"
+                    :class="`notification-type--${getSellerNotificationTypeMeta(item.type).tone}`"
+                  >
+                    {{ getSellerNotificationTypeMeta(item.type).label }}
+                  </span>
+                  <strong class="notification-title">{{ item.title }}</strong>
+                  <span v-if="!item.read" class="notification-new">NEW</span>
+                </div>
+                <span class="notification-time">{{ item.timeLabel }}</span>
+              </div>
+
+              <p class="notification-body">{{ item.body }}</p>
+            </div>
+          </button>
+        </div>
+
+        <div class="list-footer">
+          <span class="footer-text">전체 {{ filteredRows.length }}건 · 최근 7일</span>
+
+          <button class="ui-btn ui-btn--ghost" type="button" @click="handleLoadMore">
+            더 보기
+          </button>
+        </div>
+      </section>
+    </section>
+  </AppLayout>
+</template>
+
+<style scoped>
+.seller-notifications-page {
+  display: flex;
+  flex-direction: column;
+}
+
+.list-card {
+  padding: var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.toolbar,
+.filter-group,
+.summary-strip,
+.notification-top,
+.list-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.toolbar {
+  margin-bottom: var(--space-4);
+}
+
+.filter-group {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--surface);
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.filter-badge--active {
+  border-color: var(--gold);
+  background: var(--gold-pale);
+  color: var(--t1);
+}
+
+.summary-strip {
+  margin-bottom: var(--space-4);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+}
+
+.summary-text {
+  color: var(--t2);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.toolbar-message {
+  margin: 0 0 var(--space-4);
+  color: var(--blue);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.notification-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.notification-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-4);
+  width: 100%;
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  cursor: pointer;
+  text-align: left;
+}
+
+.notification-item--unread {
+  border-color: #f2c879;
+  background: #fffaf0;
+}
+
+.notification-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: var(--radius-md);
+  font-family: var(--font-condensed);
+  font-size: 22px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.notification-icon--blue,
+.notification-type--blue {
+  background: var(--blue-pale);
+  color: var(--blue);
+}
+
+.notification-icon--amber,
+.notification-type--amber {
+  background: var(--amber-pale);
+  color: #b45309;
+}
+
+.notification-icon--green,
+.notification-type--green {
+  background: var(--green-pale);
+  color: var(--green);
+}
+
+.notification-icon--red,
+.notification-type--red {
+  background: var(--red-pale);
+  color: var(--red);
+}
+
+.notification-icon--purple,
+.notification-type--purple {
+  background: var(--purple-pale);
+  color: var(--purple);
+}
+
+.notification-icon--default,
+.notification-type--default {
+  background: var(--surface-2);
+  color: var(--t3);
+}
+
+.notification-content {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.notification-top {
+  align-items: flex-start;
+}
+
+.notification-title-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.notification-type {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.notification-title {
+  color: var(--t1);
+  font-size: var(--font-size-md);
+}
+
+.notification-new {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 8px;
+  border-radius: var(--radius-full);
+  background: var(--gold);
+  color: var(--t1);
+  font-size: var(--font-size-xs);
+  font-weight: 800;
+}
+
+.notification-body,
+.notification-time,
+.footer-text {
+  margin: 0;
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+}
+
+.list-footer {
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 1100px) {
+  .toolbar,
+  .summary-strip,
+  .notification-top,
+  .list-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/src/views/seller/__tests__/channelOrders.utils.test.js
+++ b/src/views/seller/__tests__/channelOrders.utils.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  filterSellerChannelOrderRows,
+  getSellerChannelMeta,
+  getSellerChannelOrderStatusMeta,
+  SELLER_CHANNEL_ORDER_ROWS,
+} from '@/utils/channelOrders.utils.js'
+
+describe('channelOrders utils', () => {
+  it('채널 메타를 반환한다', () => {
+    expect(getSellerChannelMeta('AMAZON')).toEqual({
+      label: 'Amazon',
+      tone: 'gold',
+    })
+  })
+
+  it('주문 상태 메타를 반환한다', () => {
+    expect(getSellerChannelOrderStatusMeta('DELIVERED')).toEqual({
+      label: '배송완료',
+      tone: 'purple',
+    })
+  })
+
+  it('채널 필터를 적용한다', () => {
+    const result = filterSellerChannelOrderRows(SELLER_CHANNEL_ORDER_ROWS, {
+      channel: 'MANUAL',
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result.every((row) => row.channel === 'MANUAL')).toBe(true)
+  })
+
+  it('검색어를 적용한다', () => {
+    const result = filterSellerChannelOrderRows(SELLER_CHANNEL_ORDER_ROWS, {
+      search: 'Emily',
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].channelOrderNo).toBe('AMZ-4583201')
+  })
+})

--- a/src/views/seller/__tests__/marginSimulator.utils.test.js
+++ b/src/views/seller/__tests__/marginSimulator.utils.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildMarginScenarioCards,
+  calculateMarginResult,
+  createInitialMarginForm,
+} from '@/utils/marginSimulator.utils.js'
+
+describe('marginSimulator utils', () => {
+  it('초기 폼 기본값을 만든다', () => {
+    const form = createInitialMarginForm()
+
+    expect(form.productSku).toBe('LB-AMP-30')
+    expect(form.salesChannel).toBe('AMAZON')
+    expect(form.channelFeeRate).toBe(15)
+    expect(form.shippingMode).toBe('SEA')
+  })
+
+  it('마진 결과를 계산한다', () => {
+    const result = calculateMarginResult({
+      productSku: 'LB-AMP-30',
+      salesChannel: 'AMAZON',
+      shippingMode: 'SEA',
+      salePrice: 34,
+      channelFeeRate: 15,
+      fulfillmentFee: 2.4,
+      internationalShippingFee: 1.5,
+      otherCost: 120,
+      monthlySalesQty: 200,
+      storageUnitCost: 0.16,
+      declaredValue: 8.6,
+      dutyMode: 'rate',
+      vatRate: 10,
+      dutyRate: 8,
+      dutyAmount: 0,
+      productCost: 6.8,
+      packagingCost: 0.7,
+    })
+
+    expect(result.revenue).toBeCloseTo(6800, 2)
+    expect(result.totalCost).toBeCloseTo(3775.36, 2)
+    expect(result.netProfit).toBeCloseTo(3024.64, 2)
+    expect(result.marginRate).toBeCloseTo(44.48, 2)
+    expect(result.breakEvenUnits).toBe(8)
+  })
+
+  it('해상/현재/항공 시나리오 카드를 만든다', () => {
+    const scenarios = buildMarginScenarioCards(createInitialMarginForm())
+
+    expect(scenarios).toHaveLength(3)
+    expect(scenarios[0].label).toBe('해상 기준')
+    expect(scenarios[2].label).toBe('항공 기준')
+    expect(scenarios[0].netProfit).toBeGreaterThan(scenarios[2].netProfit)
+  })
+})

--- a/src/views/seller/__tests__/notifications.utils.test.js
+++ b/src/views/seller/__tests__/notifications.utils.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  countNotificationsByFilter,
+  countUnreadNotifications,
+  filterSellerNotifications,
+  markAllNotificationsRead,
+  SELLER_NOTIFICATION_ROWS,
+} from '@/utils/notifications.utils.js'
+
+describe('notifications utils', () => {
+  it('안읽음 개수를 계산한다', () => {
+    expect(countUnreadNotifications(SELLER_NOTIFICATION_ROWS)).toBe(3)
+  })
+
+  it('안읽음 필터를 적용한다', () => {
+    const result = filterSellerNotifications(SELLER_NOTIFICATION_ROWS, {
+      filter: 'unread',
+    })
+
+    expect(result).toHaveLength(3)
+    expect(result.every((row) => !row.read)).toBe(true)
+  })
+
+  it('유형 필터 개수를 계산한다', () => {
+    expect(countNotificationsByFilter(SELLER_NOTIFICATION_ROWS, 'LOW_STOCK')).toBe(2)
+  })
+
+  it('전체 읽음 처리된 새 배열을 만든다', () => {
+    const result = markAllNotificationsRead(SELLER_NOTIFICATION_ROWS)
+
+    expect(result.every((row) => row.read)).toBe(true)
+    expect(SELLER_NOTIFICATION_ROWS.some((row) => !row.read)).toBe(true)
+  })
+})


### PR DESCRIPTION
  ## 💡 관련 이슈
  - close #59
  - close #61 
  - close #58 
  ## 📝 변경 사항
  - Seller 도구 영역의 남은 UI 화면을 추가했습니다.
  - 주문 연동 및 조회, 마진 시뮬레이터, 알림 화면을 `UI + 로컬 mock 데이터` 기준으로 구현했습니다.
  - Seller 메뉴와 라우트에 도구 그룹을 추가하고, 화면별 유틸과 테스트를 함께 작성했습니다.

  ## 🔍 주요 작업 내용
  - [ ] Backend: 없음
  - [x] Frontend: `SELLER_NOTIFICATIONS` 라우트 상수 추가
  - [x] Frontend: Seller 메뉴에 `도구` 그룹 추가
  - [x] Frontend: 주문 연동 및 조회 화면 UI 구현
  - [x] Frontend: 채널 연결 카드 / 채널 필터 / 검색 / 통합 주문 테이블 구현
  - [x] Frontend: 마진 시뮬레이터 화면 UI 구현
  - [x] Frontend: 입력 패널 / 예상 매출·비용·순이익 / 비용 상세 / 시나리오 비교 구현
  - [x] Frontend: 알림 화면 UI 구현
  - [x] Frontend: 유형 필터 / 전체 읽음 처리 / 더 보기 / 알림 리스트 구현
  - [x] Frontend: 화면별 mock 데이터 및 계산/필터 유틸 추가
  - [x] Frontend: 화면별 유틸 테스트 추가
  - [x] Frontend: Seller 개발로그 최신화
  - [ ] DB: 없음

  ## 📸 스크린샷 (선택)
  - Seller 주문 연동 및 조회 화면
<img width="1920" height="1200" alt="스크린샷 2026-03-19 오전 10 27 49" src="https://github.com/user-attachments/assets/aabbf5b7-d6e5-45de-b98a-435472c42d31" />


  - Seller 마진 시뮬레이터 화면
<img width="1920" height="1200" alt="스크린샷 2026-03-19 오전 10 27 51" src="https://github.com/user-attachments/assets/42db0410-51ae-446a-8b09-7f3522759257" />


  - Seller 알림 화면
<img width="1920" height="1200" alt="스크린샷 2026-03-19 오전 10 27 52" src="https://github.com/user-attachments/assets/4837c9b8-6d8d-44bb-9882-171086034799" />


  ## 💬 리뷰어에게 한마디
  - 이번 PR은 UI 중심 작업이라 실제 채널 동기화, 주문 가져오기, 내보내기, 비용 preset API, 알림 API/store 연동은 아직 연결하지 않았습니다.
  - 현재는 `UI + 로컬 mock 데이터` 기준으로만 동작합니다.
  - 후속 작업 우선순위는 `알림 상태를 헤더와 통합`, `주문 등록의 UI-only 기준 정리`, `표현/빈 상태 UI 정리` 정도가 적절합니다.
