### PR TITLE
셀러 대시보드 정비

### DIFF
--- a/src/utils/sellerDashboard.utils.js
+++ b/src/utils/sellerDashboard.utils.js
@@ -1,0 +1,664 @@
+/**
+ * Seller 대시보드 화면용 파생 데이터와 차트 가공 유틸.
+ * 기존 Seller 주문/ASN/재고/채널 mock 데이터를 조합해 대시보드 요약 정보를 만든다.
+ */
+import { ASN_STATUS, ROUTE_NAMES } from '@/constants'
+
+import { getSellerAsnDetailById, SELLER_ASN_LIST_ROWS } from '@/utils/asnList.utils.js'
+import {
+  getSellerChannelMeta,
+  getSellerChannelOrderStatusMeta,
+  SELLER_CHANNEL_ORDER_ROWS,
+} from '@/utils/channelOrders.utils.js'
+import {
+  getSellerInventoryDetailById,
+  getSellerInventoryStatusMeta,
+  SELLER_INVENTORY_LIST_ROWS,
+} from '@/utils/inventoryList.utils.js'
+import {
+  getSellerOrderDetailById,
+  getSellerOrderStatusMeta,
+  SELLER_ORDER_LIST_ROWS,
+} from '@/utils/orderList.utils.js'
+
+const numberFormatter = new Intl.NumberFormat('ko-KR')
+const DASHBOARD_ACTIVITY_LIMIT = 5
+const DASHBOARD_INBOUND_LIMIT = 4
+
+const SELLER_DASHBOARD_ASN_STATUS_META = {
+  [ASN_STATUS.SUBMITTED]: { label: '등록됨', tone: 'gold' },
+  [ASN_STATUS.RECEIVED]: { label: '입고완료', tone: 'green' },
+  [ASN_STATUS.CANCELLED]: { label: '취소됨', tone: 'red' },
+}
+
+const SELLER_DASHBOARD_INBOUND_ETA_META = {
+  [ASN_STATUS.SUBMITTED]: { label: '도착 예정', tone: 'amber' },
+  [ASN_STATUS.RECEIVED]: { label: '입고완료', tone: 'green' },
+  [ASN_STATUS.CANCELLED]: { label: '일정 변경', tone: 'red' },
+}
+
+export const SELLER_DASHBOARD_PERIOD_OPTIONS = [
+  { key: 'week', label: '주간' },
+  { key: 'month', label: '월간' },
+  { key: 'quarter', label: '분기' },
+]
+
+function formatNumber(value) {
+  return numberFormatter.format(Math.max(0, Number(value) || 0))
+}
+
+function parseDashboardMetricValue(value) {
+  const normalized = String(value ?? '').replace(/[^\d.-]/g, '')
+  return Number(normalized || 0)
+}
+
+function pad(value) {
+  return String(value).padStart(2, '0')
+}
+
+function parseDateString(value) {
+  const normalized = String(value ?? '').trim()
+  if (!normalized) return null
+
+  const parsed = new Date(normalized.replace(' ', 'T'))
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+function formatDateLabel(date, { includeTime = true } = {}) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '-'
+
+  const monthDay = `${pad(date.getMonth() + 1)}/${pad(date.getDate())}`
+  if (!includeTime) return monthDay
+
+  return `${monthDay} ${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function formatMonthLabel(date) {
+  return `${date.getMonth() + 1}월`
+}
+
+function formatQuarterLabel(date) {
+  return `Q${Math.floor(date.getMonth() / 3) + 1}`
+}
+
+function formatKoreanDate(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '-'
+  return `${date.getMonth() + 1}월 ${date.getDate()}일`
+}
+
+function getDateKey(date) {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}
+
+function getMonthKey(date) {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}`
+}
+
+function getQuarterKey(date) {
+  return `${date.getFullYear()}-Q${Math.floor(date.getMonth() / 3) + 1}`
+}
+
+function shiftDate(date, { days = 0, months = 0 } = {}) {
+  const next = new Date(date)
+  next.setHours(0, 0, 0, 0)
+
+  if (months) {
+    next.setDate(1)
+    next.setMonth(next.getMonth() + months)
+  }
+
+  if (days) {
+    next.setDate(next.getDate() + days)
+  }
+
+  return next
+}
+
+function getNormalizedBaseDate(baseDate = new Date()) {
+  const parsed = baseDate instanceof Date ? new Date(baseDate) : parseDateString(baseDate)
+  const normalized = parsed && !Number.isNaN(parsed.getTime()) ? parsed : new Date()
+  normalized.setHours(0, 0, 0, 0)
+  return normalized
+}
+
+function getRecommendedMaxValue(maxValue) {
+  const safeMax = Math.max(1, Number(maxValue) || 0)
+
+  if (safeMax <= 5) return 5
+  if (safeMax <= 10) return 10
+
+  const magnitude = 10 ** Math.floor(Math.log10(safeMax))
+  return Math.ceil(safeMax / magnitude) * magnitude
+}
+
+function getAsnStatusMeta(status) {
+  return SELLER_DASHBOARD_ASN_STATUS_META[status] ?? { label: status ?? '-', tone: 'default' }
+}
+
+function getInboundEtaMeta(status) {
+  return SELLER_DASHBOARD_INBOUND_ETA_META[status] ?? { label: '확인 필요', tone: 'default' }
+}
+
+function getDashboardOutboundStage(status) {
+  if (['RECEIVED', 'NEW'].includes(status)) return 'pending'
+  if (['WAITING', 'ALLOCATED', 'DISPATCHED', 'READY', 'SHIPPED'].includes(status)) return 'progress'
+  if (['COMPLETED', 'DELIVERED'].includes(status)) return 'completed'
+  return 'ignored'
+}
+
+function normalizeDashboardOrderStatus(status) {
+  if (['NEW', 'RECEIVED'].includes(status)) return 'RECEIVED'
+  if (['READY', 'WAITING'].includes(status)) return 'WAITING'
+  if (['ALLOCATED'].includes(status)) return 'ALLOCATED'
+  if (['SHIPPED', 'DISPATCHED'].includes(status)) return 'DISPATCHED'
+  if (['DELIVERED', 'COMPLETED'].includes(status)) return 'COMPLETED'
+  return status
+}
+
+function normalizeChannelLabel(channel) {
+  if (!channel) return '-'
+  if (['Amazon', '수동', '엑셀'].includes(channel)) return channel
+  return getSellerChannelMeta(channel).label
+}
+
+function inferOrderQuantity(itemsSummary = '') {
+  const normalized = String(itemsSummary ?? '')
+  const multiplied = [...normalized.matchAll(/×\s*(\d+)/g)]
+
+  if (multiplied.length) {
+    const total = multiplied.reduce((sum, match) => sum + Number(match[1] || 0), 0)
+    return String(total)
+  }
+
+  const bundled = normalized.match(/외\s*(\d+)건/)
+  if (bundled) return String(Number(bundled[1]) + 1)
+
+  return '1'
+}
+
+function buildDashboardOrderRows(
+  orderRows = SELLER_ORDER_LIST_ROWS,
+  channelOrderRows = SELLER_CHANNEL_ORDER_ROWS,
+) {
+  const localOrders = orderRows.map((row) => ({
+    id: row.id,
+    code: row.orderNo,
+    channelLabel: normalizeChannelLabel(row.channel),
+    orderedAt: row.orderedAt,
+    itemsSummary: row.itemsSummary,
+    quantity: inferOrderQuantity(row.itemsSummary),
+    statusMeta: getSellerOrderStatusMeta(row.status),
+    stage: getDashboardOutboundStage(row.status),
+    order: {
+      ...row,
+      orderNo: row.orderNo,
+      channel: normalizeChannelLabel(row.channel),
+      status: normalizeDashboardOrderStatus(row.status),
+    },
+  }))
+
+  const syncedOrders = channelOrderRows.map((row) => ({
+    id: row.id,
+    code: row.conkOrderNo || row.channelOrderNo,
+    channelLabel: normalizeChannelLabel(row.channel),
+    orderedAt: row.orderedAt,
+    itemsSummary: row.itemsSummary,
+    quantity: inferOrderQuantity(row.itemsSummary),
+    statusMeta: getSellerChannelOrderStatusMeta(row.status),
+    stage: getDashboardOutboundStage(row.status),
+    order: {
+      id: row.id,
+      orderNo: row.conkOrderNo || row.channelOrderNo,
+      channel: normalizeChannelLabel(row.channel),
+      recipient: row.recipient,
+      address: '-',
+      itemsSummary: row.itemsSummary,
+      orderedAt: row.orderedAt,
+      status: normalizeDashboardOrderStatus(row.status),
+      trackingNo: '',
+      canCancel: false,
+    },
+  }))
+
+  return [...localOrders, ...syncedOrders]
+}
+
+function getTodayDateCounts(rows = [], baseDate = new Date()) {
+  const countsByDate = rows.reduce((map, row) => {
+    const parsed = parseDateString(row.orderedAt)
+    if (!parsed) return map
+
+    const key = getDateKey(parsed)
+    map.set(key, (map.get(key) || 0) + 1)
+    return map
+  }, new Map())
+
+  const today = getNormalizedBaseDate(baseDate)
+  const todayDateKey = getDateKey(today)
+  const previousDateKey = getDateKey(shiftDate(today, { days: -1 }))
+
+  return {
+    todayDateKey,
+    latestCount: countsByDate.get(todayDateKey) || 0,
+    previousCount: previousDateKey ? countsByDate.get(previousDateKey) || 0 : 0,
+  }
+}
+
+function buildOrderTrendMeta(latestCount, previousCount) {
+  if (!latestCount || previousCount <= 0) return {}
+
+  const delta = Math.round(((latestCount - previousCount) / previousCount) * 100)
+  if (delta > 0) return { trend: `▲ ${delta}%`, trendTone: 'up' }
+  if (delta < 0) return { trend: `▼ ${Math.abs(delta)}%`, trendTone: 'down' }
+  return {}
+}
+
+function buildTrendPeriodSeries(rows = [], period = 'month') {
+  const parsedDates = rows
+    .map((row) => parseDateString(row.orderedAt))
+    .filter(Boolean)
+
+  const latestDate = parsedDates.length
+    ? new Date(Math.max(...parsedDates.map((date) => date.getTime())))
+    : new Date()
+
+  let buckets = []
+
+  if (period === 'week') {
+    buckets = Array.from({ length: 7 }, (_, index) => {
+      const date = shiftDate(latestDate, { days: index - 6 })
+      return {
+        key: getDateKey(date),
+        label: formatDateLabel(date, { includeTime: false }),
+      }
+    })
+  } else if (period === 'quarter') {
+    buckets = Array.from({ length: 4 }, (_, index) => {
+      const date = shiftDate(latestDate, { months: (index - 3) * 3 })
+      return {
+        key: getQuarterKey(date),
+        label: formatQuarterLabel(date),
+      }
+    })
+  } else {
+    buckets = Array.from({ length: 6 }, (_, index) => {
+      const date = shiftDate(latestDate, { months: index - 5 })
+      return {
+        key: getMonthKey(date),
+        label: formatMonthLabel(date),
+      }
+    })
+  }
+
+  const counts = parsedDates.reduce((map, date) => {
+    const key = period === 'week'
+      ? getDateKey(date)
+      : period === 'quarter'
+        ? getQuarterKey(date)
+        : getMonthKey(date)
+
+    map.set(key, (map.get(key) || 0) + 1)
+    return map
+  }, new Map())
+
+  const points = buckets.map((bucket) => ({
+    label: bucket.label,
+    value: counts.get(bucket.key) || 0,
+  }))
+
+  return {
+    key: period,
+    maxValue: getRecommendedMaxValue(Math.max(...points.map((point) => point.value), 0)),
+    points,
+  }
+}
+
+export function buildSellerDashboardKpiCards({
+  inventoryRows = SELLER_INVENTORY_LIST_ROWS,
+  orderRows = SELLER_ORDER_LIST_ROWS,
+  channelOrderRows = SELLER_CHANNEL_ORDER_ROWS,
+  baseDate = new Date(),
+} = {}) {
+  const combinedOrders = buildDashboardOrderRows(orderRows, channelOrderRows)
+  const { todayDateKey, latestCount, previousCount } = getTodayDateCounts(combinedOrders, baseDate)
+  const latestRows = combinedOrders.filter((row) => {
+    const parsed = parseDateString(row.orderedAt)
+    return parsed && getDateKey(parsed) === todayDateKey
+  })
+
+  const channelSummary = latestRows.reduce((summary, row) => {
+    summary.set(row.channelLabel, (summary.get(row.channelLabel) || 0) + 1)
+    return summary
+  }, new Map())
+
+  const channelSummaryText = [...channelSummary.entries()]
+    .sort((left, right) => right[1] - left[1])
+    .slice(0, 3)
+    .map(([label, count]) => `${label} ${count}`)
+    .join(' · ')
+
+  const pendingCount = combinedOrders.filter((row) => row.stage === 'pending').length
+  const progressCount = combinedOrders.filter((row) => row.stage === 'progress').length
+  const completedCount = combinedOrders.filter((row) => row.stage === 'completed').length
+
+  const availableStock = inventoryRows.reduce((sum, row) => sum + Number(row.availableStock || 0), 0)
+  const allocatedStock = inventoryRows.reduce((sum, row) => sum + Number(row.allocatedStock || 0), 0)
+  const lowStockCount = inventoryRows.filter((row) => ['LOW', 'OUT'].includes(row.status)).length
+  const warningCount = inventoryRows.filter((row) => row.status === 'LOW').length
+  const outCount = inventoryRows.filter((row) => row.status === 'OUT').length
+  const orderTrendMeta = buildOrderTrendMeta(latestCount, previousCount)
+
+  return [
+    {
+      key: 'available-stock',
+      label: '가용 재고 총 수량',
+      value: formatNumber(availableStock),
+      subtext: `총 ${formatNumber(inventoryRows.length)} SKU · 할당재고 ${formatNumber(allocatedStock)}개 제외`,
+      tone: 'gold',
+      routeName: ROUTE_NAMES.SELLER_INVENTORY,
+    },
+    {
+      key: 'new-orders',
+      label: '금일 신규 주문',
+      value: formatNumber(latestCount),
+      subtext: channelSummaryText || '오늘 신규 주문 없음',
+      tone: 'green',
+      routeName: ROUTE_NAMES.SELLER_ORDER_LIST,
+      ...orderTrendMeta,
+    },
+    {
+      key: 'outbound-status',
+      label: '출고 처리 현황',
+      value: `${formatNumber(pendingCount)} · ${formatNumber(progressCount)} · ${formatNumber(completedCount)}`,
+      subtext: '대기 · 진행 · 완료',
+      tone: 'blue',
+      routeName: ROUTE_NAMES.SELLER_ORDER_LIST,
+    },
+    {
+      key: 'low-stock',
+      label: '재고 부족 알림 SKU',
+      value: formatNumber(lowStockCount),
+      subtext: `재고부족 ${formatNumber(warningCount)} · 품절 ${formatNumber(outCount)}`,
+      tone: 'amber',
+      routeName: ROUTE_NAMES.SELLER_INVENTORY,
+    },
+  ]
+}
+
+export function buildSellerDashboardTrendSeries({
+  orderRows = SELLER_ORDER_LIST_ROWS,
+  channelOrderRows = SELLER_CHANNEL_ORDER_ROWS,
+} = {}) {
+  const combinedOrders = buildDashboardOrderRows(orderRows, channelOrderRows)
+
+  return {
+    week: buildTrendPeriodSeries(combinedOrders, 'week'),
+    month: buildTrendPeriodSeries(combinedOrders, 'month'),
+    quarter: buildTrendPeriodSeries(combinedOrders, 'quarter'),
+  }
+}
+
+export function buildSellerDashboardStockRatio({
+  inventoryRows = SELLER_INVENTORY_LIST_ROWS,
+} = {}) {
+  const availableStock = inventoryRows.reduce((sum, row) => sum + Number(row.availableStock || 0), 0)
+  const allocatedStock = inventoryRows.reduce((sum, row) => sum + Number(row.allocatedStock || 0), 0)
+  const inboundExpected = inventoryRows.reduce((sum, row) => sum + Number(row.inboundExpected || 0), 0)
+  const total = Math.max(availableStock + allocatedStock + inboundExpected, 1)
+
+  const availableShare = Math.round((availableStock / total) * 100)
+  const allocatedShare = Math.round((allocatedStock / total) * 100)
+  const inboundShare = Math.max(0, 100 - availableShare - allocatedShare)
+
+  return [
+    { key: 'available', label: '가용재고', value: availableShare, color: '#F5A623' },
+    { key: 'allocated', label: '할당재고', value: allocatedShare, color: '#4C74FF' },
+    { key: 'inbound', label: '입고예정', value: inboundShare, color: '#7B859A' },
+  ]
+}
+
+export function buildSellerDashboardRecentActivityRows({
+  orderRows = SELLER_ORDER_LIST_ROWS,
+  channelOrderRows = SELLER_CHANNEL_ORDER_ROWS,
+  asnRows = SELLER_ASN_LIST_ROWS,
+  inventoryRows = SELLER_INVENTORY_LIST_ROWS,
+} = {}) {
+  const orderActivities = buildDashboardOrderRows(orderRows, channelOrderRows).map((row) => {
+    const orderedAt = parseDateString(row.orderedAt)
+
+    return {
+      id: `activity-${row.id}`,
+      type: '주문',
+      typeTone: 'gold',
+      code: row.code,
+      target: row.itemsSummary,
+      quantity: row.quantity,
+      statusLabel: row.statusMeta.label,
+      statusTone: row.statusMeta.tone,
+      occurredAt: formatDateLabel(orderedAt),
+      routeName: ROUTE_NAMES.SELLER_ORDER_LIST,
+      order: row.order,
+      orderDetail: getSellerOrderDetailById(row.order.id, row.order),
+      sortAt: orderedAt?.getTime() || 0,
+    }
+  })
+
+  const asnActivities = asnRows.map((row) => {
+    const createdAt = parseDateString(`${row.createdAt} 09:00`)
+    const statusMeta = getAsnStatusMeta(row.status)
+
+    return {
+      id: `activity-${row.id}`,
+      type: 'ASN',
+      typeTone: 'blue',
+      code: row.asnNo,
+      target: row.warehouseName,
+      quantity: formatNumber(row.totalQuantity),
+      statusLabel: statusMeta.label,
+      statusTone: statusMeta.tone,
+      occurredAt: formatDateLabel(createdAt, { includeTime: false }),
+      routeName: ROUTE_NAMES.SELLER_ASN_LIST,
+      sortAt: createdAt?.getTime() || 0,
+    }
+  })
+
+  const inventoryActivities = inventoryRows
+    .filter((row) => row.status !== 'NORMAL')
+    .map((row) => {
+      const occurredAt = parseDateString(`${row.lastInboundDate} 08:00`)
+      const statusMeta = getSellerInventoryStatusMeta(row.status)
+
+      return {
+        id: `activity-${row.id}`,
+        type: '재고',
+        typeTone: 'default',
+        code: row.sku,
+        target: row.productName,
+        quantity: formatNumber(row.availableStock),
+        statusLabel: statusMeta.label,
+        statusTone: statusMeta.tone,
+        occurredAt: formatDateLabel(occurredAt, { includeTime: false }),
+        routeName: ROUTE_NAMES.SELLER_INVENTORY,
+        sortAt: occurredAt?.getTime() || 0,
+      }
+    })
+
+  return [...orderActivities, ...asnActivities, ...inventoryActivities]
+    .sort((left, right) => right.sortAt - left.sortAt)
+    .slice(0, DASHBOARD_ACTIVITY_LIMIT)
+    .map(({ sortAt, ...row }) => row)
+}
+
+export function buildSellerDashboardInboundRows({
+  asnRows = SELLER_ASN_LIST_ROWS,
+  inventoryRows = SELLER_INVENTORY_LIST_ROWS,
+} = {}) {
+  const inboundScheduleBySku = asnRows
+    .slice()
+    .sort((left, right) => {
+      const leftDate = parseDateString(left.expectedDate)?.getTime() || 0
+      const rightDate = parseDateString(right.expectedDate)?.getTime() || 0
+      return rightDate - leftDate
+    })
+    .reduce((map, row) => {
+      const detail = getSellerAsnDetailById(row.id, row)
+      const expectedDate = parseDateString(row.expectedDate)
+
+      detail.items.forEach((item) => {
+        if (map.has(item.sku)) return
+
+        map.set(item.sku, {
+          asnNo: row.asnNo,
+          status: row.status,
+          expectedDate,
+          quantity: Number(item.quantity ?? 0),
+        })
+      })
+
+      return map
+    }, new Map())
+
+  return inventoryRows
+    .filter((row) => Number(row.inboundExpected) > 0)
+    .map((row) => {
+      const schedule = inboundScheduleBySku.get(row.sku)
+      const expectedDate = schedule?.expectedDate ?? null
+      const etaMeta = getInboundEtaMeta(schedule?.status)
+      const inventoryDetail = getSellerInventoryDetailById(row.id, row)
+      const expectedQty = Number(schedule?.quantity ?? row.inboundExpected ?? 0)
+      const inventory = schedule ? { ...row, inboundExpected: expectedQty } : row
+
+      return {
+        id: `inbound-${row.id}`,
+        period: formatKoreanDate(expectedDate),
+        sku: row.sku,
+        productName: row.productName,
+        expectedQty: formatNumber(expectedQty),
+        etaLabel: etaMeta.label,
+        etaTone: etaMeta.tone,
+        inventory,
+        inventoryDetail: schedule?.asnNo
+          ? { ...inventoryDetail, nextInboundAsnNo: schedule.asnNo }
+          : inventoryDetail,
+        routeName: ROUTE_NAMES.SELLER_ASN_LIST,
+        sortAt: expectedDate?.getTime() ?? -1,
+        sortQty: expectedQty,
+      }
+    })
+    .sort((left, right) => {
+      if (left.sortAt !== right.sortAt) return right.sortAt - left.sortAt
+      return right.sortQty - left.sortQty
+    })
+    .slice(0, DASHBOARD_INBOUND_LIMIT)
+    .map(({ sortAt, sortQty, ...row }) => row)
+}
+
+export const SELLER_DASHBOARD_KPI_CARDS = buildSellerDashboardKpiCards()
+export const SELLER_DASHBOARD_TREND_SERIES = buildSellerDashboardTrendSeries()
+export const SELLER_DASHBOARD_STOCK_RATIO = buildSellerDashboardStockRatio()
+export const SELLER_DASHBOARD_RECENT_ACTIVITY_ROWS = buildSellerDashboardRecentActivityRows()
+export const SELLER_DASHBOARD_INBOUND_ROWS = buildSellerDashboardInboundRows()
+
+export function getSellerDashboardTrendSeries(period = 'month') {
+  return SELLER_DASHBOARD_TREND_SERIES[period] ?? SELLER_DASHBOARD_TREND_SERIES.month
+}
+
+export function buildSellerDashboardTrendChart(points = [], { maxValue = 500 } = {}) {
+  const normalizedPoints = Array.isArray(points) ? points : []
+  const left = 110
+  const right = 660
+  const top = 36
+  const baseline = 180
+  const chartHeight = baseline - top
+  const denominator = Math.max(Number(maxValue) || 0, 1)
+  const step = normalizedPoints.length > 1 ? (right - left) / (normalizedPoints.length - 1) : 0
+
+  const chartPoints = normalizedPoints.map((point, index) => {
+    const normalizedValue = Math.max(0, Number(point.value) || 0)
+    const x = left + (step * index)
+    const y = baseline - ((normalizedValue / denominator) * chartHeight)
+
+    return {
+      x: Math.round(x),
+      y: Math.round(y),
+      label: point.label,
+      value: normalizedValue,
+    }
+  })
+
+  const linePoints = chartPoints.map((point) => `${point.x},${point.y}`).join(' ')
+  const firstPoint = chartPoints[0]
+  const lastPoint = chartPoints[chartPoints.length - 1]
+  const areaPoints = chartPoints.length
+    ? `${linePoints} ${lastPoint.x},${baseline} ${firstPoint.x},${baseline}`
+    : ''
+  const yLabels = Array.from({ length: 5 }, (_, index) => {
+    const value = denominator - ((denominator / 5) * index)
+    const y = 24 + (40 * index)
+
+    return {
+      value: Math.round(value),
+      y,
+    }
+  })
+
+  return {
+    linePoints,
+    areaPoints,
+    points: chartPoints,
+    xLabels: chartPoints.map((point) => ({
+      label: point.label,
+      x: point.x,
+    })),
+    yLabels,
+  }
+}
+
+export function buildSellerDashboardDonutSegments(items = [], circumference = 377) {
+  const normalizedItems = Array.isArray(items) ? items : []
+  let offset = 0
+
+  return normalizedItems.map((item) => {
+    const value = Math.max(0, Number(item.value) || 0)
+    const segmentLength = Number(((value / 100) * circumference).toFixed(2))
+    const segment = {
+      ...item,
+      dasharray: `${segmentLength} ${circumference}`,
+      dashoffset: Number((-offset).toFixed(2)),
+    }
+
+    offset += segmentLength
+    return segment
+  })
+}
+
+export function buildSellerDashboardViewState({
+  kpiCards = [],
+  trendSeries = null,
+  recentActivityRows = [],
+  inboundRows = [],
+  isLoading = false,
+  errorMessage = '',
+} = {}) {
+  const normalizedErrorMessage = String(errorMessage ?? '').trim()
+  const normalizedTrendPoints = Array.isArray(trendSeries?.points) ? trendSeries.points : []
+  const hasKpiData = (Array.isArray(kpiCards) ? kpiCards : []).some((card) => {
+    return parseDashboardMetricValue(card?.value) > 0
+  })
+  const hasTrendData = normalizedTrendPoints.some((point) => Number(point?.value || 0) > 0)
+  const hasRecentActivity = Array.isArray(recentActivityRows) && recentActivityRows.length > 0
+  const hasInboundRows = Array.isArray(inboundRows) && inboundRows.length > 0
+  const hasError = Boolean(normalizedErrorMessage)
+  const hasContent = hasKpiData || hasTrendData || hasRecentActivity || hasInboundRows
+
+  return {
+    isLoading: Boolean(isLoading),
+    hasError,
+    errorMessage: normalizedErrorMessage,
+    isEmpty: !isLoading && !hasError && !hasContent,
+    hasKpiData,
+    hasTrendData,
+    hasRecentActivity,
+    hasInboundRows,
+  }
+}

--- a/src/views/seller/SellerDashboardView.vue
+++ b/src/views/seller/SellerDashboardView.vue
@@ -1,219 +1,520 @@
 <script setup>
 /**
  * 셀러 대시보드 화면.
- * 실제 API 연동 전까지 로컬 mock 데이터를 사용해 운영 현황을 렌더링한다.
+ * Figma export 기준으로 KPI, 추이 차트, 도넛 차트, 하단 테이블 레이아웃을 먼저 맞춘다.
  */
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
 import { ROUTE_NAMES } from '@/constants'
 import AppLayout from '@/components/layout/AppLayout.vue'
+import SellerInventoryDetailModal from '@/components/seller/SellerInventoryDetailModal.vue'
+import SellerOrderDetailModal from '@/components/seller/SellerOrderDetailModal.vue'
+import {
+  buildSellerDashboardDonutSegments,
+  buildSellerDashboardTrendChart,
+  buildSellerDashboardViewState,
+  getSellerDashboardTrendSeries,
+  SELLER_DASHBOARD_INBOUND_ROWS,
+  SELLER_DASHBOARD_KPI_CARDS,
+  SELLER_DASHBOARD_PERIOD_OPTIONS,
+  SELLER_DASHBOARD_RECENT_ACTIVITY_ROWS,
+  SELLER_DASHBOARD_STOCK_RATIO,
+} from '@/utils/sellerDashboard.utils.js'
 
-/** Header 브레드크럼 표시용 */
-const breadcrumb = [{ label: 'Seller' }, { label: 'Dashboard' }]
+const breadcrumb = [{ label: 'Seller' }, { label: '대시보드' }]
+const activePeriod = ref('month')
+const router = useRouter()
+// TODO(owner): Replace mock state flags with dashboard API request state once backend contract is ready.
+const isDashboardLoading = ref(false)
+const dashboardErrorMessage = ref('')
+const selectedRecentOrder = ref(null)
+const selectedRecentOrderDetail = ref(null)
+const isRecentOrderDetailOpen = ref(false)
+const selectedInboundInventory = ref(null)
+const selectedInboundInventoryDetail = ref(null)
+const isInboundInventoryDetailOpen = ref(false)
 
-// 셀러 대시보드 API 가 준비되기 전까지 화면에서 사용하는 로컬 mock 데이터.
-const dashboardData = {
-  // 상단 KPI 카드에 표시할 요약 수치.
-  summary: {
-    availableStockQty: 12840,
-    availableSkuCount: 236,
-    todayNewOrders: 87,
-    outbound: {
-      pending: 12,
-      inProgress: 31,
-      completed: 44,
-    },
-    lowStockSkuCount: 9,
-  },
-  // 운영 메모나 임시 공지를 보여주는 배너 데이터.
-  memoBanner: {
-    title: '운영 메모',
-    message: '금주 입고 예정 물량이 증가하여 ASN 등록 일정 확인 필요',
-    updatedAt: '2026-03-17 09:00',
-  },
-  // 최근 7일 주문/출고 추이를 직접 그리기 위한 데이터.
-  weeklyTrend: [
-    { label: '03/11', orders: 42, shipped: 35 },
-    { label: '03/12', orders: 51, shipped: 39 },
-    { label: '03/13', orders: 48, shipped: 41 },
-    { label: '03/14', orders: 66, shipped: 52 },
-    { label: '03/15', orders: 73, shipped: 61 },
-    { label: '03/16', orders: 58, shipped: 46 },
-    { label: '03/17', orders: 87, shipped: 44 },
-  ],
-  // 재고 상태 비율 영역에 사용하는 데이터.
-  ratioChart: [
-    { label: '정상 재고', value: 78 },
-    { label: '할당 재고', value: 15 },
-    { label: '부족 재고', value: 7 },
-  ],
-  // 하단 최근 활동 패널에 사용하는 피드 데이터.
-  recentActivities: [
-    { id: 1, type: 'ORDER', message: '주문 12건이 신규 등록됨', time: '10분 전' },
-    { id: 2, type: 'ASN', message: 'ASN-20260317-001 입고 완료', time: '32분 전' },
-    { id: 3, type: 'ALERT', message: 'SKU-203 재고 부족 알림 발생', time: '1시간 전' },
-  ],
-  // 하단 입고 예정 재고 목록 패널에 사용하는 데이터.
-  inboundInventory: [
-    { id: 1, asnNo: 'ASN-20260317-001', warehouse: 'NJ Warehouse', qty: 1200, eta: '2026-03-19', status: '입고예정' },
-    { id: 2, asnNo: 'ASN-20260316-004', warehouse: 'LA Warehouse', qty: 860, eta: '2026-03-18', status: '입고중' },
-  ],
+const dashboardKpiCards = computed(() => SELLER_DASHBOARD_KPI_CARDS)
+const newOrdersCard = computed(() => {
+  return dashboardKpiCards.value.find((card) => card.key === 'new-orders') ?? null
+})
+const outboundStatusCard = computed(() => {
+  return dashboardKpiCards.value.find((card) => card.key === 'outbound-status') ?? null
+})
+const availableStockCard = computed(() => {
+  return dashboardKpiCards.value.find((card) => card.key === 'available-stock') ?? null
+})
+const lowStockCard = computed(() => {
+  return dashboardKpiCards.value.find((card) => card.key === 'low-stock') ?? null
+})
+const inventorySummaryRouteName = computed(() => {
+  return lowStockCard.value?.routeName ?? availableStockCard.value?.routeName ?? null
+})
+const currentTrendSeries = computed(() => getSellerDashboardTrendSeries(activePeriod.value))
+const trendChart = computed(() => {
+  return buildSellerDashboardTrendChart(currentTrendSeries.value.points, {
+    maxValue: currentTrendSeries.value.maxValue,
+  })
+})
+const stockRatio = computed(() => SELLER_DASHBOARD_STOCK_RATIO)
+const recentActivityRows = computed(() => SELLER_DASHBOARD_RECENT_ACTIVITY_ROWS)
+const inboundRows = computed(() => SELLER_DASHBOARD_INBOUND_ROWS)
+const dashboardViewState = computed(() => {
+  return buildSellerDashboardViewState({
+    kpiCards: dashboardKpiCards.value,
+    trendSeries: currentTrendSeries.value,
+    recentActivityRows: recentActivityRows.value,
+    inboundRows: inboundRows.value,
+    isLoading: isDashboardLoading.value,
+    errorMessage: dashboardErrorMessage.value,
+  })
+})
+const donutSegments = computed(() => buildSellerDashboardDonutSegments(stockRatio.value))
+const donutTotal = computed(() => {
+  return stockRatio.value.reduce((sum, item) => sum + Number(item.value || 0), 0)
+})
+
+function navigateToRoute(name) {
+  if (!name) return
+  router.push({ name })
 }
 
+function handleRecentActivityCodeClick(row) {
+  if (row.type === '주문' && row.order) {
+    selectedRecentOrder.value = row.order
+    selectedRecentOrderDetail.value = row.orderDetail
+    isRecentOrderDetailOpen.value = true
+    return
+  }
+
+  navigateToRoute(row.routeName)
+}
+
+function handleCloseRecentOrderDetail() {
+  isRecentOrderDetailOpen.value = false
+  selectedRecentOrder.value = null
+  selectedRecentOrderDetail.value = null
+}
+
+function handleInboundSkuClick(row) {
+  if (!row.inventory) {
+    navigateToRoute(row.routeName)
+    return
+  }
+
+  selectedInboundInventory.value = row.inventory
+  selectedInboundInventoryDetail.value = row.inventoryDetail
+  isInboundInventoryDetailOpen.value = true
+}
+
+function handleCloseInboundInventoryDetail() {
+  isInboundInventoryDetailOpen.value = false
+  selectedInboundInventory.value = null
+  selectedInboundInventoryDetail.value = null
+}
+
+function handleRetryDashboard() {
+  dashboardErrorMessage.value = ''
+}
 </script>
 
 <template>
-  <AppLayout title="Seller Dashboard" :breadcrumb="breadcrumb">
+  <AppLayout title="대시보드" :breadcrumb="breadcrumb">
     <template #header-action>
-      <!-- 현재 연결된 두 개의 셀러 작업 화면으로 바로 이동하는 CTA -->
       <RouterLink :to="{ name: ROUTE_NAMES.SELLER_ASN_CREATE }" class="ui-btn ui-btn--ghost">ASN 등록</RouterLink>
       <RouterLink :to="{ name: ROUTE_NAMES.SELLER_ORDER_REGISTER }" class="ui-btn ui-btn--primary">주문 등록</RouterLink>
     </template>
 
     <section class="seller-dashboard">
-      <!-- KPI 카드 4개 영역 -->
-      <div class="kpi-grid">
-        <div class="dashboard-card">
-          <p class="card-label">가용 재고 총 수량</p>
-          <strong class="card-value">{{ dashboardData.summary.availableStockQty }}</strong>
-          <span class="card-sub">{{ dashboardData.summary.availableSkuCount }} SKU</span>
-        </div>
+      <section v-if="dashboardViewState.isLoading" class="dashboard-state">
+        <p class="dashboard-state__eyebrow">Loading</p>
+        <strong class="dashboard-state__title">대시보드 데이터를 불러오는 중입니다.</strong>
+        <p class="dashboard-state__copy">Seller 운영 현황을 정리하는 동안 잠시만 기다려주세요.</p>
+      </section>
 
-        <div class="dashboard-card">
-          <p class="card-label">금일 신규 주문</p>
-          <strong class="card-value">{{ dashboardData.summary.todayNewOrders }}</strong>
-          <span class="card-sub">오늘 기준 신규 등록 건수</span>
-        </div>
+      <section v-else-if="dashboardViewState.hasError" class="dashboard-state dashboard-state--error">
+        <p class="dashboard-state__eyebrow">Load Failed</p>
+        <strong class="dashboard-state__title">대시보드 데이터를 불러오지 못했습니다.</strong>
+        <p class="dashboard-state__copy">{{ dashboardViewState.errorMessage }}</p>
+        <button type="button" class="ui-btn ui-btn--ghost" @click="handleRetryDashboard">다시 불러오기</button>
+      </section>
 
-        <div class="dashboard-card">
-          <p class="card-label">출고 처리 현황</p>
-          <strong class="card-value">{{ dashboardData.summary.outbound.completed }}</strong>
-          <span class="card-sub">대기 {{ dashboardData.summary.outbound.pending }} / 진행 {{ dashboardData.summary.outbound.inProgress }}
-          </span>
-        </div>
+      <section v-else-if="dashboardViewState.isEmpty" class="dashboard-state">
+        <p class="dashboard-state__eyebrow">No Data</p>
+        <strong class="dashboard-state__title">표시할 운영 데이터가 없습니다.</strong>
+        <p class="dashboard-state__copy">주문 등록 또는 ASN 등록 후 운영 현황을 이 화면에서 확인할 수 있습니다.</p>
+      </section>
 
-        <div class="dashboard-card">
-          <p class="card-label">재고 부족 알림</p>
-          <strong class="card-value">{{ dashboardData.summary.lowStockSkuCount }}</strong>
-          <span class="card-sub">안전재고 이하 SKU 수</span>
-        </div>
-      </div>
+      <template v-else>
+        <section class="kpi-grid">
+          <button
+            v-if="newOrdersCard"
+            type="button"
+            class="dashboard-card kpi-card kpi-card--interactive"
+            @click="navigateToRoute(newOrdersCard.routeName)"
+          >
+            <div class="kpi-card-head">
+              <span class="kpi-label">{{ newOrdersCard.label }}</span>
+              <span class="kpi-icon" :class="`kpi-icon--${newOrdersCard.tone}`" />
+            </div>
 
+            <strong class="kpi-value">{{ newOrdersCard.value }}</strong>
 
-      <!-- 운영 메모 배너 -->
-      <div class="dashboard-card dashboard-banner">
-        <p class="card-label">{{ dashboardData.memoBanner.title }}</p>
-        <strong class="banner-message">{{ dashboardData.memoBanner.message }}</strong>
-        <span class="card-sub">업데이트: {{ dashboardData.memoBanner.updatedAt }}</span>
-      </div>
+            <div class="kpi-meta">
+              <span
+                v-if="newOrdersCard.trend"
+                class="kpi-trend"
+                :class="`kpi-trend--${newOrdersCard.trendTone}`"
+              >
+                {{ newOrdersCard.trend }}
+              </span>
+              <span class="kpi-sub">{{ newOrdersCard.subtext }}</span>
+            </div>
+          </button>
 
-      <!-- 차트 2개 영역 -->
-      <div class="chart-grid">
-        <div class="dashboard-card">
-          <div class="section-head">
-            <h2 class="section-title">주간 주문/출고 추이</h2>
-            <span class="section-count">최근 7일</span>
-          </div>
+          <button
+            v-if="outboundStatusCard"
+            type="button"
+            class="dashboard-card kpi-card kpi-card--interactive"
+            @click="navigateToRoute(outboundStatusCard.routeName)"
+          >
+            <div class="kpi-card-head">
+              <span class="kpi-label">{{ outboundStatusCard.label }}</span>
+              <span class="kpi-icon" :class="`kpi-icon--${outboundStatusCard.tone}`" />
+            </div>
 
-          <div class="trend-chart">
-            <div
-                v-for="item in dashboardData.weeklyTrend"
-                :key="item.label"
-                class="trend-item"
-            >
-              <div class="trend-bars">
-                <span class="trend-bar trend-bar--orders" :style="{ height: `${item.orders}px` }" />
-                <span class="trend-bar trend-bar--shipped" :style="{ height: `${item.shipped}px` }" />
+            <strong class="kpi-value">{{ outboundStatusCard.value }}</strong>
+
+            <div class="kpi-meta">
+              <span class="kpi-sub">{{ outboundStatusCard.subtext }}</span>
+            </div>
+          </button>
+
+          <button
+            v-if="availableStockCard || lowStockCard"
+            type="button"
+            class="dashboard-card kpi-card kpi-card--interactive kpi-card--split"
+            @click="navigateToRoute(inventorySummaryRouteName)"
+          >
+            <div v-if="availableStockCard" class="kpi-split-item">
+              <div class="kpi-card-head">
+                <span class="kpi-label">{{ availableStockCard.label }}</span>
+                <span class="kpi-icon" :class="`kpi-icon--${availableStockCard.tone}`" />
               </div>
-              <span class="trend-label">{{ item.label }}</span>
+
+              <strong class="kpi-value">{{ availableStockCard.value }}</strong>
+              <div class="kpi-meta">
+                <span class="kpi-sub">{{ availableStockCard.subtext }}</span>
+              </div>
+            </div>
+
+            <div v-if="lowStockCard" class="kpi-split-item">
+              <div class="kpi-card-head">
+                <span class="kpi-label">{{ lowStockCard.label }}</span>
+                <span class="kpi-icon" :class="`kpi-icon--${lowStockCard.tone}`" />
+              </div>
+
+              <strong class="kpi-value">{{ lowStockCard.value }}</strong>
+              <div class="kpi-meta">
+                <span class="kpi-sub">{{ lowStockCard.subtext }}</span>
+              </div>
+            </div>
+          </button>
+        </section>
+
+        <section class="charts-row">
+        <article class="dashboard-card chart-card chart-card--wide">
+          <div class="chart-head">
+            <div>
+              <p class="section-eyebrow">Order Trend</p>
+              <h2 class="section-title">기간별 주문 추이</h2>
+            </div>
+
+            <div class="period-toggle">
+              <button
+                v-for="option in SELLER_DASHBOARD_PERIOD_OPTIONS"
+                :key="option.key"
+                type="button"
+                class="period-btn"
+                :class="{ 'period-btn--active': activePeriod === option.key }"
+                @click="activePeriod = option.key"
+              >
+                {{ option.label }}
+              </button>
             </div>
           </div>
 
-          <p class="chart-note">주문 / 출고</p>
-        </div>
+          <div class="line-chart-wrap">
+            <div v-if="!dashboardViewState.hasTrendData" class="chart-empty">
+              기간별 주문 데이터가 아직 없습니다.
+            </div>
+            <svg viewBox="0 0 680 220" preserveAspectRatio="none" aria-hidden="true">
+              <template v-if="dashboardViewState.hasTrendData">
+              <defs>
+                <linearGradient id="sellerDashboardGoldGrad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stop-color="#F5A623" />
+                  <stop offset="100%" stop-color="#F5A623" stop-opacity="0" />
+                </linearGradient>
+              </defs>
 
-        <div class="dashboard-card">
-          <div class="section-head">
-            <h2 class="section-title">비율 차트</h2>
-            <span class="section-count">재고 상태</span>
+              <line x1="60" y1="20" x2="660" y2="20" class="chart-grid-line" stroke-dasharray="4" />
+              <line x1="60" y1="60" x2="660" y2="60" class="chart-grid-line" stroke-dasharray="4" />
+              <line x1="60" y1="100" x2="660" y2="100" class="chart-grid-line" stroke-dasharray="4" />
+              <line x1="60" y1="140" x2="660" y2="140" class="chart-grid-line" stroke-dasharray="4" />
+              <line x1="60" y1="180" x2="660" y2="180" class="chart-grid-line" />
+
+              <text
+                v-for="label in trendChart.yLabels"
+                :key="`y-${label.value}`"
+                x="50"
+                :y="label.y"
+                text-anchor="end"
+                class="chart-axis-label"
+              >
+                {{ label.value }}
+              </text>
+
+              <text
+                v-for="label in trendChart.xLabels"
+                :key="`x-${label.label}`"
+                :x="label.x"
+                y="200"
+                text-anchor="middle"
+                class="chart-axis-label"
+              >
+                {{ label.label }}
+              </text>
+
+              <polygon :points="trendChart.areaPoints" class="chart-area" />
+              <polyline :points="trendChart.linePoints" class="chart-line" />
+
+              <circle
+                v-for="point in trendChart.points"
+                :key="`${point.label}-${point.x}`"
+                :cx="point.x"
+                :cy="point.y"
+                :r="point.label === trendChart.points.at(-1)?.label ? 5 : 4"
+                class="chart-dot"
+              />
+              </template>
+            </svg>
+          </div>
+        </article>
+
+        <article class="dashboard-card chart-card chart-card--narrow">
+          <div class="chart-head">
+            <div>
+              <p class="section-eyebrow">Stock Mix</p>
+              <h2 class="section-title">재고 구성 비율</h2>
+            </div>
           </div>
 
-          <ul class="ratio-list">
-            <li
-                v-for="(item, index) in dashboardData.ratioChart"
-                :key="item.label"
-                class="ratio-item"
-            >
-              <div class="ratio-meta">
-                <span :class="`ratio-dot ratio-dot--${index}`" />
-                <span class="ratio-label">{{ item.label }}</span>
-                <strong class="ratio-value">{{ item.value }}%</strong>
-              </div>
-              <div class="ratio-track">
-                <span :class="`ratio-fill ratio-fill--${index}`" :style="{ width: `${item.value}%` }" />
-              </div>
-            </li>
-          </ul>
-        </div>
-      </div>
+          <div class="donut-wrap">
+            <svg class="donut-svg" viewBox="0 0 160 160" aria-hidden="true">
+              <circle cx="80" cy="80" r="60" fill="none" stroke="#F3F5F8" stroke-width="22" />
+              <circle
+                v-for="segment in donutSegments"
+                :key="segment.key"
+                cx="80"
+                cy="80"
+                r="60"
+                fill="none"
+                :stroke="segment.color"
+                stroke-width="22"
+                :stroke-dasharray="segment.dasharray"
+                :stroke-dashoffset="segment.dashoffset"
+                transform="rotate(-90 80 80)"
+              />
+              <text x="80" y="76" text-anchor="middle" class="donut-total">
+                {{ donutTotal }}
+              </text>
+              <text x="80" y="94" text-anchor="middle" class="donut-copy">재고 구성 비율</text>
+            </svg>
 
-      <!-- 하단 테이블 2개 영역 - 최근 활동, 기간별 입고 재고 목록 -->
-      <div class="table-grid">
-        <div class="dashboard-card">
-          <div class="section-head">
-            <h2 class="section-title">최근 활동</h2>
-            <span class="section-count">{{ dashboardData.recentActivities.length }}건</span>
+            <div class="donut-legend">
+              <div
+                v-for="segment in stockRatio"
+                :key="segment.key"
+                class="legend-item"
+              >
+                <span class="legend-dot" :style="{ backgroundColor: segment.color }" />
+                <span class="legend-label">{{ segment.label }}</span>
+                <strong class="legend-value">{{ segment.value }}%</strong>
+              </div>
+            </div>
+          </div>
+        </article>
+        </section>
+
+        <section class="tables-row">
+        <article class="dashboard-card table-card">
+          <div class="table-head">
+            <div>
+              <p class="section-eyebrow">Recent Feed</p>
+              <h2 class="section-title">최근 활동</h2>
+            </div>
+            <button
+              type="button"
+              class="table-more"
+              @click="navigateToRoute(ROUTE_NAMES.SELLER_NOTIFICATIONS)"
+            >
+              전체보기 →
+            </button>
           </div>
 
-          <ul class="activity-list">
-            <li
-                v-for="activity in dashboardData.recentActivities"
-                :key="activity.id"
-                class="activity-item"
-            >
-              <div class="activity-main">
-                <strong class="activity-type">{{ activity.type }}</strong>
-                <p class="activity-message">{{ activity.message }}</p>
-              </div>
-              <span class="activity-time">{{ activity.time }}</span>
-            </li>
-          </ul>
-        </div>
+          <div class="table-wrap">
+            <table v-if="dashboardViewState.hasRecentActivity" class="dash-table">
+              <thead>
+                <tr>
+                  <th>구분</th>
+                  <th>번호</th>
+                  <th>대상</th>
+                  <th>수량</th>
+                  <th>상태</th>
+                  <th>일시</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in recentActivityRows" :key="row.id">
+                  <td>
+                    <span class="row-tag" :class="`row-tag--${row.typeTone}`">{{ row.type }}</span>
+                  </td>
+                  <td>
+                    <button type="button" class="row-link" @click="handleRecentActivityCodeClick(row)">
+                      {{ row.code }}
+                    </button>
+                  </td>
+                  <td>{{ row.target }}</td>
+                  <td>{{ row.quantity }}</td>
+                  <td>
+                    <span class="status-badge" :class="`status-badge--${row.statusTone}`">
+                      {{ row.statusLabel }}
+                    </span>
+                  </td>
+                  <td>{{ row.occurredAt }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <div v-else class="table-empty">
+              최근 활동이 아직 없습니다.
+            </div>
+          </div>
+        </article>
 
-        <div class="dashboard-card">
-          <div class="section-head">
-            <h2 class="section-title">기간별 입고 재고 목록</h2>
-            <span class="section-count">{{ dashboardData.inboundInventory.length }}건</span>
+        <article class="dashboard-card table-card">
+          <div class="table-head">
+            <div>
+              <p class="section-eyebrow">Inbound Schedule</p>
+              <h2 class="section-title">기간별 입고 재고 목록</h2>
+            </div>
+            <button
+              type="button"
+              class="table-more"
+              @click="navigateToRoute(ROUTE_NAMES.SELLER_ASN_LIST)"
+            >
+              전체보기 →
+            </button>
           </div>
 
-          <ul class="inventory-list">
-            <li
-                v-for="item in dashboardData.inboundInventory"
-                :key="item.id"
-                class="inventory-item"
-            >
-              <div class="inventory-main">
-                <strong class="inventory-id">{{ item.asnNo }}</strong>
-                <p class="inventory-meta">{{ item.warehouse }} · ETA {{ item.eta }}</p>
-              </div>
-
-              <div class="inventory-side">
-                <strong class="inventory-qty">{{ item.qty }}</strong>
-                <span class="inventory-status">{{ item.status }}</span>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </div>
-
+          <div class="table-wrap">
+            <table v-if="dashboardViewState.hasInboundRows" class="dash-table">
+              <thead>
+                <tr>
+                  <th>기간</th>
+                  <th>SKU</th>
+                  <th>상품</th>
+                  <th>입고 예정</th>
+                  <th>ETA</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in inboundRows" :key="row.id">
+                  <td class="row-code">{{ row.period }}</td>
+                  <td>
+                    <button type="button" class="row-link" @click="handleInboundSkuClick(row)">
+                      {{ row.sku }}
+                    </button>
+                  </td>
+                  <td>{{ row.productName }}</td>
+                  <td>{{ row.expectedQty }}</td>
+                  <td>
+                    <span class="status-badge" :class="`status-badge--${row.etaTone}`">
+                      {{ row.etaLabel }}
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div v-else class="table-empty">
+              예정된 입고 재고가 없습니다.
+            </div>
+          </div>
+        </article>
+        </section>
+      </template>
     </section>
+
+    <SellerOrderDetailModal
+      :is-open="isRecentOrderDetailOpen"
+      :order="selectedRecentOrder"
+      :detail="selectedRecentOrderDetail"
+      @cancel="handleCloseRecentOrderDetail"
+    />
+
+    <SellerInventoryDetailModal
+      :is-open="isInboundInventoryDetailOpen"
+      :inventory="selectedInboundInventory"
+      :detail="selectedInboundInventoryDetail"
+      @cancel="handleCloseInboundInventoryDetail"
+    />
   </AppLayout>
 </template>
 
 <style scoped>
-/* 대시보드 레이아웃 골격 Style */
 .seller-dashboard {
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
+}
+
+.dashboard-state {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: 28px 32px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.dashboard-state--error {
+  border-color: rgba(191, 38, 38, 0.18);
+  background: rgba(191, 38, 38, 0.03);
+}
+
+.dashboard-state__eyebrow {
+  margin: 0;
+  color: var(--blue);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dashboard-state__title {
+  color: var(--t1);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+}
+
+.dashboard-state__copy {
+  margin: 0;
+  color: var(--t3);
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
 }
 
 .kpi-grid {
@@ -222,287 +523,450 @@ const dashboardData = {
   gap: var(--space-4);
 }
 
-.chart-grid,
-.table-grid {
+.charts-row,
+.tables-row {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
   gap: var(--space-4);
 }
 
 .dashboard-card {
-  min-height: 180px;
-  padding: var(--space-5);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--surface);
   box-shadow: var(--shadow-sm);
 }
 
-.dashboard-banner {
-  min-height: 120px;
+.kpi-card {
+  padding: 22px 24px;
+  text-align: left;
 }
-/* kpi 카드 style */
-.card-label {
-  font-size: var(--font-size-sm);
+
+.kpi-card--split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-column: span 2;
+  padding: 0;
+  overflow: hidden;
+}
+
+.kpi-card--interactive {
+  width: 100%;
+  border: 1px solid var(--border);
+  cursor: pointer;
+}
+
+.kpi-split-item {
+  width: 100%;
+  padding: 22px 24px;
+  text-align: left;
+}
+
+.kpi-split-item + .kpi-split-item {
+  border-left: 1px solid var(--border);
+}
+
+.kpi-card--interactive:hover {
+  border-color: rgba(245, 166, 35, 0.45);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.kpi-card-head,
+.chart-head,
+.table-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.kpi-label,
+.kpi-sub,
+.section-eyebrow,
+.chart-axis-label,
+.legend-label,
+.table-more,
+.dash-table th,
+.dash-table td {
+  font-size: var(--font-size-xs);
+}
+
+.kpi-label,
+.kpi-sub,
+.section-eyebrow,
+.chart-axis-label,
+.legend-label,
+.dash-table th {
   color: var(--t3);
 }
 
-.card-value {
+.chart-axis-label {
+  font-weight: 600;
+  letter-spacing: 0;
+  text-rendering: geometricPrecision;
+}
+
+.section-eyebrow {
+  margin: 0 0 var(--space-2);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--blue);
+}
+
+.section-title {
+  margin: 0;
+  color: var(--t1);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+}
+
+.kpi-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+}
+
+.kpi-icon--gold {
+  background: var(--gold-pale);
+}
+
+.kpi-icon--green {
+  background: var(--green-pale);
+}
+
+.kpi-icon--blue {
+  background: var(--blue-pale);
+}
+
+.kpi-icon--amber {
+  background: rgba(245, 166, 35, 0.16);
+}
+
+.kpi-value {
   display: block;
   margin-top: var(--space-3);
   font-family: var(--font-condensed);
   font-size: 32px;
+  line-height: 1.1;
   color: var(--t1);
-  line-height: 1;
 }
 
-.card-sub {
-  display: block;
+.kpi-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
   margin-top: var(--space-2);
-  font-size: var(--font-size-sm);
-  color: var(--t3);
-}
-.banner-message {
-  display: block;
-  margin-top: var(--space-3);
-  font-size: var(--font-size-lg);
-  font-weight: 600;
-  color: var(--t1);
-  line-height: 1.5;
 }
 
-/* 최근 활등 Style */
-.section-head {
+.kpi-trend {
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.kpi-trend--up {
+  color: var(--green);
+}
+
+.kpi-trend--down {
+  color: var(--red);
+}
+
+.chart-card,
+.table-card {
+  padding: 24px;
+}
+
+.chart-card--narrow .chart-head {
+  margin-bottom: var(--space-5);
+}
+
+.period-toggle {
+  display: flex;
+  gap: 4px;
+}
+
+.period-btn {
+  min-height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--t3);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.period-btn--active {
+  border-color: var(--gold);
+  background: var(--gold);
+  color: #0d0d0d;
+}
+
+.line-chart-wrap {
+  width: 100%;
+  height: 220px;
+  overflow-x: auto;
+}
+
+.chart-empty,
+.table-empty {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: var(--space-4);
-}
-
-.section-title {
-  font-size: var(--font-size-lg);
-  font-weight: 600;
-  color: var(--t1);
-}
-
-.section-count {
-  font-size: var(--font-size-sm);
+  justify-content: center;
+  min-height: 180px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
   color: var(--t3);
+  font-size: var(--font-size-sm);
+  text-align: center;
 }
 
-.activity-list {
+.line-chart-wrap svg {
+  width: 100%;
+  height: 100%;
+  min-width: 680px;
+}
+
+.chart-grid-line {
+  stroke: var(--border);
+  stroke-width: 1;
+}
+
+.chart-line {
+  fill: none;
+  stroke: var(--gold);
+  stroke-width: 2.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.chart-area {
+  fill: url(#sellerDashboardGoldGrad);
+  opacity: 0.18;
+}
+
+.chart-dot {
+  fill: var(--gold);
+  stroke: #fff;
+  stroke-width: 2;
+}
+
+.donut-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+}
+
+.donut-svg {
+  width: 160px;
+  height: 160px;
+}
+
+.donut-total {
+  fill: var(--t1);
+  font-family: var(--font-condensed);
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.donut-copy {
+  fill: var(--t3);
+  font-size: 10px;
+}
+
+.donut-legend {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 12px;
+  min-width: 140px;
 }
 
-.activity-item {
+.legend-item {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--border);
+  align-items: center;
+  gap: 8px;
 }
 
-.activity-item:first-child {
-  padding-top: 0;
-  border-top: none;
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
 }
 
-.activity-main {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-.activity-type {
+.legend-value {
+  margin-left: auto;
+  color: var(--t1);
   font-size: var(--font-size-xs);
-  color: var(--blue);
+  font-weight: 700;
 }
 
-.activity-message {
-  font-size: var(--font-size-md);
+.table-more {
+  border: none;
+  background: transparent;
+  color: var(--blue);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.table-wrap {
+  margin-top: var(--space-4);
+  overflow-x: auto;
+}
+
+.dash-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.dash-table th,
+.dash-table td {
+  padding: 11px 12px;
+  text-align: left;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--border);
+}
+
+.dash-table th {
+  background: var(--surface-2);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.dash-table td {
   color: var(--t2);
 }
 
-.activity-time {
-  font-size: var(--font-size-sm);
-  color: var(--t3);
+.dash-table tr:last-child td {
+  border-bottom: none;
+}
+
+.row-code {
+  color: var(--blue);
+  font-weight: 700;
+}
+
+.row-link {
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--blue);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.row-link:hover {
+  text-decoration: underline;
+}
+
+.row-tag,
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
+  padding: 0 10px;
+  border-radius: 4px;
+  font-size: var(--font-size-xs);
+  font-weight: 700;
   white-space: nowrap;
 }
 
-/* 기간별 입고 재고 목록 Style */
-.inventory-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
+.row-tag--gold {
+  background: var(--gold-pale);
+  color: #92400e;
 }
 
-.inventory-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--border);
-}
-
-.inventory-item:first-child {
-  padding-top: 0;
-  border-top: none;
-}
-
-.inventory-main {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-
-.inventory-id {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-sm);
-  color: var(--t1);
-}
-
-.inventory-meta {
-  font-size: var(--font-size-sm);
-  color: var(--t3);
-}
-
-.inventory-side {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: var(--space-1);
-}
-
-.inventory-qty {
-  font-family: var(--font-condensed);
-  font-size: var(--font-size-lg);
-  color: var(--t1);
-}
-
-.inventory-status {
-  font-size: var(--font-size-sm);
+.row-tag--blue {
+  background: var(--blue-pale);
   color: var(--blue);
 }
 
-/* 차트 부분 Style */
-.trend-chart {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: var(--space-3);
-  min-height: 180px;
-}
-
-.trend-item {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.trend-bars {
-  width: 100%;
-  min-height: 140px;
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  gap: 6px;
-}
-
-.trend-bar {
-  width: 14px;
-  border-radius: var(--radius-full);
-}
-
-.trend-bar--orders {
-  background: var(--blue);
-}
-
-.trend-bar--shipped {
-  background: var(--gold);
-}
-
-.trend-label {
-  font-size: var(--font-size-xs);
-  color: var(--t3);
-}
-
-.chart-note {
-  margin-top: var(--space-3);
-  font-size: var(--font-size-sm);
-  color: var(--t3);
-}
-
-.ratio-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-}
-
-.ratio-item {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
-.ratio-meta {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.ratio-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: var(--radius-full);
-}
-
-.ratio-dot--0,
-.ratio-fill--0 {
-  background: var(--green);
-}
-
-.ratio-dot--1,
-.ratio-fill--1 {
-  background: var(--blue);
-}
-
-.ratio-dot--2,
-.ratio-fill--2 {
-  background: var(--red);
-}
-
-.ratio-label {
-  flex: 1;
-  font-size: var(--font-size-md);
-  color: var(--t2);
-}
-
-.ratio-value {
-  font-family: var(--font-condensed);
-  font-size: var(--font-size-lg);
-  color: var(--t1);
-}
-
-.ratio-track {
-  width: 100%;
-  height: 10px;
+.row-tag--default {
   background: var(--surface-2);
-  border-radius: var(--radius-full);
-  overflow: hidden;
+  color: var(--t3);
 }
 
-.ratio-fill {
-  display: block;
-  height: 100%;
-  border-radius: var(--radius-full);
+.status-badge--green {
+  background: var(--green-pale);
+  color: var(--green);
 }
 
+.status-badge--amber {
+  background: rgba(245, 166, 35, 0.16);
+  color: #92400e;
+}
 
+.status-badge--blue {
+  background: var(--blue-pale);
+  color: var(--blue);
+}
+
+.status-badge--red {
+  background: var(--red-pale);
+  color: #7f1d1d;
+}
+
+.status-badge--gold {
+  background: var(--gold-pale);
+  color: #92400e;
+}
+
+@media (max-width: 1200px) {
+  .kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .kpi-card--split {
+    grid-column: span 2;
+  }
+
+  .charts-row,
+  .tables-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .kpi-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .kpi-card--split {
+    grid-template-columns: 1fr;
+    grid-column: auto;
+  }
+
+  .kpi-split-item + .kpi-split-item {
+    border-left: none;
+    border-top: 1px solid var(--border);
+  }
+
+  .kpi-card,
+  .chart-card,
+  .table-card {
+    padding: 20px;
+  }
+
+  .chart-head,
+  .table-head,
+  .donut-wrap {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .period-toggle {
+    flex-wrap: wrap;
+  }
+
+  .donut-svg {
+    width: 144px;
+    height: 144px;
+  }
+}
 </style>

--- a/src/views/seller/__tests__/sellerDashboard.utils.test.js
+++ b/src/views/seller/__tests__/sellerDashboard.utils.test.js
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildSellerDashboardInboundRows,
+  buildSellerDashboardDonutSegments,
+  buildSellerDashboardKpiCards,
+  buildSellerDashboardRecentActivityRows,
+  buildSellerDashboardStockRatio,
+  buildSellerDashboardTrendChart,
+  buildSellerDashboardViewState,
+  getSellerDashboardTrendSeries,
+  SELLER_DASHBOARD_KPI_CARDS,
+  SELLER_DASHBOARD_STOCK_RATIO,
+  SELLER_DASHBOARD_TREND_SERIES,
+} from '@/utils/sellerDashboard.utils.js'
+
+describe('sellerDashboard utils', () => {
+  it('기존 Seller 화면 데이터로 KPI 카드를 계산한다', () => {
+    expect(SELLER_DASHBOARD_KPI_CARDS).toEqual(buildSellerDashboardKpiCards())
+    expect(buildSellerDashboardKpiCards({
+      baseDate: new Date('2026-03-19T12:00:00'),
+    })).toEqual([
+      expect.objectContaining({
+        key: 'available-stock',
+        value: '1,488',
+        routeName: 'seller-inventory',
+      }),
+      expect.objectContaining({
+        key: 'new-orders',
+        value: '2',
+        trend: '▼ 50%',
+        routeName: 'seller-order-list',
+      }),
+      expect.objectContaining({
+        key: 'outbound-status',
+        value: '3 · 8 · 4',
+      }),
+      expect.objectContaining({
+        key: 'low-stock',
+        value: '3',
+        subtext: '재고부족 2 · 품절 1',
+      }),
+    ])
+  })
+
+  it('금일 신규 주문은 실제 기준일 하루만 집계한다', () => {
+    const cards = buildSellerDashboardKpiCards({
+      baseDate: new Date('2026-03-21T12:00:00'),
+    })
+
+    expect(cards[1]).toEqual(
+      expect.objectContaining({
+        key: 'new-orders',
+        value: '0',
+        subtext: '오늘 신규 주문 없음',
+      }),
+    )
+    expect(cards[1].trend).toBeUndefined()
+  })
+
+  it('기간 키가 없으면 월간 추이 데이터를 반환한다', () => {
+    expect(getSellerDashboardTrendSeries('unknown')).toEqual(SELLER_DASHBOARD_TREND_SERIES.month)
+  })
+
+  it('기간별 추이 데이터는 기존 주문 목록 기준으로 집계된다', () => {
+    expect(SELLER_DASHBOARD_TREND_SERIES.month.points).toEqual([
+      { label: '10월', value: 0 },
+      { label: '11월', value: 0 },
+      { label: '12월', value: 0 },
+      { label: '1월', value: 0 },
+      { label: '2월', value: 0 },
+      { label: '3월', value: 16 },
+    ])
+    expect(SELLER_DASHBOARD_TREND_SERIES.month.maxValue).toBe(20)
+  })
+
+  it('추이 차트용 line/area 좌표를 생성한다', () => {
+    const result = buildSellerDashboardTrendChart(
+      [
+        { label: '1월', value: 100 },
+        { label: '2월', value: 200 },
+        { label: '3월', value: 300 },
+      ],
+      { maxValue: 300 },
+    )
+
+    expect(result.linePoints).toBe('110,132 385,84 660,36')
+    expect(result.areaPoints).toBe('110,132 385,84 660,36 660,180 110,180')
+    expect(result.xLabels).toEqual([
+      { label: '1월', x: 110 },
+      { label: '2월', x: 385 },
+      { label: '3월', x: 660 },
+    ])
+    expect(result.yLabels[0]).toEqual({ value: 300, y: 24 })
+  })
+
+  it('기간 변경 시 축 라벨 좌표를 정수 픽셀로 맞춘다', () => {
+    const result = buildSellerDashboardTrendChart(SELLER_DASHBOARD_TREND_SERIES.week.points, {
+      maxValue: SELLER_DASHBOARD_TREND_SERIES.week.maxValue,
+    })
+
+    expect(result.xLabels.every((label) => Number.isInteger(label.x))).toBe(true)
+    expect(result.points.every((point) => Number.isInteger(point.x) && Number.isInteger(point.y))).toBe(true)
+  })
+
+  it('도넛 차트용 stroke 길이와 오프셋을 계산한다', () => {
+    const result = buildSellerDashboardDonutSegments(SELLER_DASHBOARD_STOCK_RATIO)
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        key: 'available',
+        dasharray: '241.28 377',
+        dashoffset: 0,
+      }),
+      expect.objectContaining({
+        key: 'allocated',
+        dasharray: '33.93 377',
+        dashoffset: -241.28,
+      }),
+      expect.objectContaining({
+        key: 'inbound',
+        dasharray: '101.79 377',
+        dashoffset: -275.21,
+      }),
+    ])
+  })
+
+  it('대시보드 뷰 상태에서 빈 데이터와 오류 상태를 구분한다', () => {
+    expect(buildSellerDashboardViewState({
+      kpiCards: [
+        { value: '0' },
+        { value: '0' },
+        { value: '0 · 0 · 0' },
+        { value: '0' },
+      ],
+      trendSeries: { points: [{ label: '1월', value: 0 }] },
+      recentActivityRows: [],
+      inboundRows: [],
+    })).toEqual(
+      expect.objectContaining({
+        isEmpty: true,
+        hasTrendData: false,
+        hasRecentActivity: false,
+        hasInboundRows: false,
+      }),
+    )
+
+    expect(buildSellerDashboardViewState({
+      errorMessage: '대시보드 조회 실패',
+    })).toEqual(
+      expect.objectContaining({
+        hasError: true,
+        errorMessage: '대시보드 조회 실패',
+        isEmpty: false,
+      }),
+    )
+  })
+
+  it('재고 비율과 하단 목록도 기존 Seller 데이터에서 계산한다', () => {
+    expect(buildSellerDashboardStockRatio()).toEqual([
+      { key: 'available', label: '가용재고', value: 64, color: '#F5A623' },
+      { key: 'allocated', label: '할당재고', value: 9, color: '#4C74FF' },
+      { key: 'inbound', label: '입고예정', value: 27, color: '#7B859A' },
+    ])
+
+    expect(buildSellerDashboardRecentActivityRows()[0]).toEqual(
+      expect.objectContaining({
+        code: 'ORD-20260319-001',
+        order: expect.objectContaining({
+          orderNo: 'ORD-20260319-001',
+          channel: 'Amazon',
+        }),
+        orderDetail: expect.objectContaining({
+          receiverPhone: '+1-000-000-0000',
+        }),
+        routeName: 'seller-order-list',
+      }),
+    )
+
+    expect(buildSellerDashboardViewState({
+      kpiCards: SELLER_DASHBOARD_KPI_CARDS,
+      trendSeries: SELLER_DASHBOARD_TREND_SERIES.month,
+      recentActivityRows: buildSellerDashboardRecentActivityRows(),
+      inboundRows: buildSellerDashboardInboundRows(),
+    })).toEqual(
+      expect.objectContaining({
+        isEmpty: false,
+        hasKpiData: true,
+        hasTrendData: true,
+        hasRecentActivity: true,
+        hasInboundRows: true,
+      }),
+    )
+
+    expect(buildSellerDashboardInboundRows()[0]).toEqual(
+      expect.objectContaining({
+        period: '3월 21일',
+        sku: 'LB-AMP-30',
+        expectedQty: '180',
+        inventory: expect.objectContaining({
+          id: 'seller-inventory-1',
+          sku: 'LB-AMP-30',
+          inboundExpected: 180,
+        }),
+        inventoryDetail: expect.objectContaining({
+          nextInboundAsnNo: 'ASN-20260318-001',
+        }),
+        routeName: 'seller-asn-list',
+      }),
+    )
+
+    const matchedMaskRow = buildSellerDashboardInboundRows().find((row) => row.sku === 'LB-MSK-5P')
+    expect(matchedMaskRow).toEqual(
+      expect.objectContaining({
+        period: '3월 19일',
+        expectedQty: '100',
+        etaLabel: '도착 예정',
+      }),
+    )
+  })
+})


### PR DESCRIPTION
• ## 💡 관련 이슈
  - close #87 

  ## 📝 변경 사항
상단 레이아웃 4개 중 2개가 중복된 같은 화면으로 이동하여 1개 레이아웃으로 묶었습니다.
또한, 차트 재구성 및 각 레이아웃 클릭 시 해당 목록 페이지로 이동 / 최근활동, 기간별 입고 재고 목록 클릭 시 상세 정보 모달로 이동하게끔 재정비 진행했습니다.
  - Seller 대시보드 화면을 Figma 기준으로 다시 정리함
  - KPI, 차트, 하단 테이블 구조를 정비하고 데이터 정합성을 맞춤
  - 최근 활동 / 입고 목록 상세 확인 흐름과 기본 상태 UI를 추가

  ## 🔍 주요 작업 내용

  - [x] Frontend: 대시보드 상단 타이틀을 `대시보드`로 정리하고 CTA 버튼은 기존 구조 유지
  - [x] Frontend: KPI 레이아웃을 `금일 신규 주문`, `출고 처리 현황`, `가용재고 / 재고부족 합본 카드` 구조로 재배치
  - [x] Frontend: 합본 KPI 카드는 좌우를 따로 누르지 않고 카드 전체가 한 번에 동작하도록 정리
  - [x] Frontend: 추이 차트를 `주간 / 월간 / 분기` 토글이 있는 `기간별 주문 추이`로 정리
  - [x] Frontend: 도넛 차트 제목과 항목을 `재고 구성 비율`, `가용재고 / 할당재고 / 입고예정` 기준으로 정리
  - [x] Frontend: 최근 활동 주문번호 클릭 시 주문 상세 모달 오픈
  - [x] Frontend: 기간별 입고 재고 목록 SKU 클릭 시 재고 상세 모달 오픈
  - [x] Frontend: 금일 신규 주문 계산 기준을 실제 오늘 날짜 기준으로 보정
  - [x] Frontend: 입고 목록이 재고 row 와 ASN row 를 index 로 섞지 않고 SKU 기준 ASN 상세 품목과 매칭되도록 보정
  - [x] Frontend: 대시보드 `loading / error / empty` 상태와 차트/테이블 empty state 추가
  - [x] Frontend: Seller 대시보드 유틸 테스트 보강 및 문서 동기화


  ## 📸 스크린샷 (선택)
  - 대시보드 전체 화면
<img width="2560" height="1237" alt="스크린샷 2026-03-21 오후 5 31 51" src="https://github.com/user-attachments/assets/576e1205-4c37-4390-ac2f-d74dc70cb037" />

  - KPI 재배치 영역
<img width="2253" height="173" alt="스크린샷 2026-03-21 오후 5 32 06" src="https://github.com/user-attachments/assets/78dcdf0b-2590-40bc-a7fe-127c92ff6725" />

  - 최근 활동 주문 상세 모달
<img width="2302" height="1134" alt="스크린샷 2026-03-21 오후 5 32 26" src="https://github.com/user-attachments/assets/6c30b9de-e906-4908-a31b-781977a13c23" />

  - 입고 재고 목록 재고 상세 모달
<img width="2304" height="1128" alt="스크린샷 2026-03-21 오후 5 32 33" src="https://github.com/user-attachments/assets/fe8fe2ee-6c51-4e6f-92b3-c7e14e999193" />

  - loading / error / empty 상태 화면
<img width="1920" height="976" alt="스크린샷 2026-03-21 오후 5 34 55" src="https://github.com/user-attachments/assets/f1a2da50-1d22-46cf-87e8-d9d9e9ccb01f" />
<img width="1920" height="979" alt="스크린샷 2026-03-21 오후 5 35 30" src="https://github.com/user-attachments/assets/af7e6ba7-aab1-4048-8e42-555162f66524" />


  ## 💬 리뷰어에게 한마디
  - 공통 컴포넌트는 건드리지 않고 Seller 대시보드 범위 안에서만 정리했습니다.
  - 현재 기준으로는 mock 데이터 기반 화면/흐름 정리까지 완료된 상태입니다.
  - 확인 포인트는 KPI 클릭 동선, `주간 / 월간 / 분기` 전환, 최근 활동 주문 모달, 입고 목록 SKU 모달입니다.